### PR TITLE
docs(theme): update theme-system.md to reflect role-based typography scale

### DIFF
--- a/techspec/theme-system.md
+++ b/techspec/theme-system.md
@@ -10,7 +10,7 @@
   - `@theme {}` — tokens estáticos (radius, tracking, font families); gera classes nativas (`rounded-xl`, `tracking-label`, `font-display`)
   - `@theme inline {}` — mapeia variáveis semânticas para classes Tailwind (`bg-surface`, `text-foreground`, `shadow-brand`, etc.)
   - `:root` / `.dark` — aliases do shadcn/ui
-- Utilitários de tipografia via `@utility`: `label-xs`, `label`, `label-wide`, `display-sm`, `display-md`, `display-lg`, `score`
+- Utilitários de tipografia via `@utility`: escala de 10 papéis — `display`, `headline`, `title`, `subtitle`, `body`, `body-sm`, `label`, `label-sm`, `label-wide`, `caption`
 - Provider em `src/components/theme/theme-provider.tsx`: estado, persistência e sincronização com sistema
 - Script inline em `src/app/layout.tsx` evita flash de tema errado antes da hidratação
 - `useTheme()` é estrito: falha explicitamente fora de `ThemeProvider`
@@ -23,7 +23,7 @@
 ### Categorias em `globals.css`
 
 - **Foundation (estáticos em `@theme`):** radius (`--radius-sm` → `--radius-pill`), tracking (`--tracking-label`, `--tracking-label-wide`), font families (`--font-body`, `--font-display`)
-- **Foundation (em `:root`):** shadow values (`--shadow-sm-value` etc.), font sizes (`--fz-label`, `--fz-display-lg`, etc.) — prefixo `--fz-*` evita colisão com o namespace `--text-*` do Tailwind v4
+- **Foundation (em `:root`):** shadow values (`--shadow-sm-value` etc.), font sizes (`--fz-label`, `--fz-title`, `--fz-display`, etc.) — prefixo `--fz-*` evita colisão com o namespace `--text-*` do Tailwind v4
 - **Semantic surfaces:** `surface`, `surface-emphasis`, `surface-strong`
 - **Brand/team:** `--team-alpha`, `--team-alpha-soft`, `--team-beta`, `--team-beta-soft` e variantes por estado de liderança
 - **Shell autenticada:** `--app-shell-sidebar`, `--app-shell-sidebar-hover`, `--app-shell-sidebar-active`


### PR DESCRIPTION
## O que muda

- Atualiza lista de utilitários de tipografia: substitui os 7 utilitários antigos (`label-xs`, `display-sm/md/lg`, `score`, etc.) pelos 10 papéis da nova escala (`display`, `headline`, `title`, `subtitle`, `body`, `body-sm`, `label`, `label-sm`, `label-wide`, `caption`)
- Corrige exemplo de token `--fz-display-lg` para `--fz-title` e `--fz-display`, refletindo os tokens renomeados em `tokens.css`

## Como testar

- [ ] Verificar que `techspec/theme-system.md` documenta corretamente os utilitários e tokens atuais

🤖 Generated with [Claude Code](https://claude.com/claude-code)