### PR TITLE
chore: improve agent rules with path scoping and why explanations

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,16 +1,24 @@
+---
+# No path scope — these constraints apply to the entire codebase.
+---
+
 # Architecture
 
 ## Constraints
 
 These rules apply for v1 and must not be broken without an explicit product or architecture decision:
 
-- Do not introduce a separate backend service
-- Do not generalize to multi-team or multi-league
-- Do not persist aggregated scoreboard counters — scoreboard is always derived from `matches`
-- Do not treat the database `teams` table as the sole source of truth; teams are mirrored in `src/lib/constants.ts` and seeded into the DB
-- Do not break the in-memory fallback without explicit approval
-- Do not document the in-memory fallback as if it re-opens the authenticated flow; it is restricted to domain use and local development only
-- Any change to team ids or team shape requires updating code, schema, and seed together
+- Do not introduce a separate backend service. **Why:** Adds operational complexity and a network boundary for no user benefit at this scale.
+- Do not generalize to multi-team or multi-league. **Why:** The two-team model is load-bearing — constants, seed, and UI all assume exactly two teams.
+- Do not persist aggregated scoreboard counters — scoreboard is always derived from `matches`. **Why:** Stored counters can diverge from match history; derivation is the single source of truth.
+- Do not treat the database `teams` table as the sole source of truth; teams are mirrored in `src/lib/constants.ts` and seeded into the DB. **Why:** In-memory mode has no DB; constants must always be authoritative.
+- Do not break the in-memory fallback without explicit approval. **Why:** It is the local dev path and the test harness for all unit/route tests.
+- Do not document the in-memory fallback as if it re-opens the authenticated flow; it is restricted to domain use and local development only.
+- Any change to team ids or team shape requires updating code, schema, and seed together. **Why:** Divergence between constants and seed causes silent failures in both modes.
+
+## CI / Deploy Changes
+
+When touching GitHub Actions, release flow, or Vercel config, read `techspec/github-operations.md` and `techspec/git-conventions.md` before editing. Constraint: keep Vercel as deployment platform; GitHub is for validation only.
 
 ## Layer Map
 
@@ -26,4 +34,3 @@ These rules apply for v1 and must not be broken without an explicit product or a
 | Auth | `src/lib/auth.ts`, `src/lib/auth-validation.ts`, `src/lib/auth-rate-limit.ts` |
 | Middleware | `middleware.ts` |
 | Persistence | `prisma/schema.prisma`, `prisma/seed.mjs`, `src/lib/prisma.ts` |
-

--- a/.claude/rules/auth.md
+++ b/.claude/rules/auth.md
@@ -1,9 +1,22 @@
+---
+paths:
+  - "src/lib/auth*.ts"
+  - "src/app/api/**/*.ts"
+  - "middleware.ts"
+---
+
 # Auth
 
 ## Availability Chain
 
-- `isAuthAvailable()` requires both `hasDatabaseUrl()` and `hasAuthSecret()` to be true. Missing `DATABASE_URL` returns 503; `DATABASE_URL` without `NEXTAUTH_SECRET` returns 500 -- never treat it as a degraded fallback. Middleware checks these at module level and throws on misconfiguration.
+- Call `isAuthAvailable()` before any auth operation. It requires both `hasDatabaseUrl()` and `hasAuthSecret()`.
+- Missing `DATABASE_URL` → return 503 (service unavailable — DB is the dependency).
+- `DATABASE_URL` present without `NEXTAUTH_SECRET` → return 500 (misconfiguration — never treat as degraded mode). Middleware checks these at module level and throws on misconfiguration.
+- **Why:** The client error-handling branches on these specific codes. Silently degrading breaks the UX flow and masks real configuration errors in production.
 
 ## Rate Limiting
 
-- Rate limiting is Prisma-backed, keyed by `action:email:ip`. Call sequence: `buildAuthRateLimitKey()`, `getAuthRateLimitStatus()`, `registerAuthFailure()` on failure, `clearAuthRateLimit()` on success. Blocked requests return 429 with `retryAfterSeconds`; block duration escalates exponentially (15m, 30m, 60m max). Unavailable in in-memory mode.
+- Rate limiting is Prisma-backed, keyed by `action:email:ip`. Call sequence: `buildAuthRateLimitKey()`, `getAuthRateLimitStatus()`, `registerAuthFailure()` on failure, `clearAuthRateLimit()` on success.
+- Blocked requests return 429 with `retryAfterSeconds`; block duration escalates exponentially (15m, 30m, 60m max).
+- Not available in in-memory mode — do not call rate-limit functions when `DATABASE_URL` is absent.
+- **Why:** Skipping the sequence (e.g. clearing on failure) silently disables lockout and leaves brute-force protection broken.

--- a/.claude/rules/domain.md
+++ b/.claude/rules/domain.md
@@ -1,18 +1,24 @@
+---
+paths:
+  - "src/lib/**"
+  - "src/app/api/**/*.ts"
+  - "prisma/**"
+---
+
 # Domain
 
 ## Invariants
 
-- Only two valid team ids: `frontend` and `backend`
-- Team definitions are hard-coded in `src/lib/constants.ts`
-- Scoreboard values are always derived from `matches` — never stored as counters
-- `leaderTeamId` is `null` on ties
-- `leadBy` is the absolute win difference
-- `currentStreak` counts consecutive wins backward from the newest match until a different winner appears
-- `getScoreboard()` fetches **all** match records with no limit; `listMatches()` defaults to 12 for UI display. Adding a limit to `getScoreboard()` silently produces wrong `wins`, `leadBy`, and `currentStreak` values.
+- Only two valid team ids: `frontend` and `backend` — defined in `src/lib/constants.ts`.
+- Scoreboard values are always derived from `matches` — never stored as counters.
+- `leaderTeamId` is `null` on ties; `leadBy` is the absolute win difference.
+- `currentStreak` counts consecutive wins backward from the newest match until a different winner appears.
+- `getScoreboard()` fetches **all** match records with no limit. **Why:** Adding a limit silently produces wrong `wins`, `leadBy`, and `currentStreak` — there is no error, just wrong data.
+- `listMatches()` defaults to 12 for UI display — this limit is intentional and UI-only.
 
 ## Team Behavior Files
 
-When touching team behavior, review all of:
+When touching anything team-related, review all of:
 
 - `src/lib/constants.ts`
 - `src/lib/types.ts`
@@ -20,4 +26,3 @@ When touching team behavior, review all of:
 - `src/app/api/matches/route.ts`
 - `prisma/seed.mjs`
 - `prisma/schema.prisma`
-

--- a/.claude/rules/safe-change.md
+++ b/.claude/rules/safe-change.md
@@ -1,128 +1,17 @@
+---
+# No path scope — applies globally before finishing any task.
+---
+
 # Safe Change Checklist
 
-Before finishing, check:
+For authenticated shell or sidebar layout changes, read `techspec/sidebar-layout.md` first.
+
+Before finishing, verify:
 
 1. Does the app still support both persistence modes (Prisma and in-memory)?
-2. Is the scoreboard still derived from match history?
-3. Are `frontend` and `backend` still the only accepted team ids unless the task explicitly changed that?
-4. Did `/dashboard` remain the real functional flow while `/scoreboard` stayed available as a legacy redirect?
+2. Is the scoreboard still derived from match history — no stored counters introduced?
+3. Are `frontend` and `backend` still the only accepted team ids (unless the task explicitly changed that)?
+4. Did `/dashboard` remain the functional route while `/scoreboard` stayed as a legacy redirect?
 5. Did API response shapes stay compatible with the current UI?
 6. Did login, signup, and protected routes stay consistent with the current auth model?
-7. Did you update docs only where behavior actually changed?
-
----
-
-## Task Routing Guide
-
-Use as the default review map before editing.
-
-### GitHub Actions or repository operations
-
-Read:
-1. `techspec/github-operations.md`
-2. `README.md`
-3. `package.json`
-4. `.github/workflows/*`
-
-Constraint: keep Vercel as deployment platform; use GitHub for validation only. If the task changes release or deploy behavior, also review `techspec/git-conventions.md` and `vercel.json`.
-
-### Scoreboard or match-history changes
-
-Read:
-1. `src/lib/data.ts`
-2. `src/lib/types.ts`
-3. `src/app/api/matches/route.ts`
-4. `src/app/api/scoreboard/route.ts`
-5. Relevant dashboard components and tests
-
-### Dashboard UI changes
-
-Read:
-1. `src/components/dashboard/index.tsx`
-2. `src/components/dashboard/use-dashboard-data.ts`
-3. Relevant subcomponents in `src/components/dashboard/`
-4. `src/components/dashboard.test.tsx`
-5. `src/components/ui/composition.test.tsx` when shared composition primitives are involved
-
-### Theme system changes
-
-Read:
-1. `src/app/globals.css`
-2. `src/components/theme/theme-provider.tsx`
-3. `src/components/theme/theme-core.ts`
-4. `src/components/ui/` — componentes base shadcn/ui
-5. `src/components/primitives/` — primitivos de composição do domínio
-6. `techspec/theme-system.md`
-
-Constraint: prefer semantic tokens over per-component color overrides; keep `useTheme()` strict. Use native token classes (`rounded-xl`, `shadow-brand`) instead of arbitrary `[var(--...)]` values.
-
-### Shell or authenticated layout changes
-
-Read:
-1. `src/app/(authenticated)/layout.tsx`
-2. `src/components/authenticated/app-shell.tsx`
-3. `middleware.ts`
-4. `techspec/sidebar-layout.md`
-
-Constraint: do not break `/scoreboard` legacy redirect or duplicate route protection inconsistently between middleware and pages.
-
-### Login/auth changes
-
-Read:
-1. `src/app/page.tsx`
-2. `src/app/login/page.tsx`
-3. `src/components/login/login-screen.tsx`
-4. `src/components/login/login-screen.test.tsx`
-5. `src/lib/auth-validation.ts` when validation rules are involved
-
-Constraint: keep auth simple unless the user explicitly asks to extend it.
-
-### Persistence or schema changes
-
-Read:
-1. `prisma/schema.prisma`
-2. `prisma/seed.mjs`
-3. `src/lib/data.ts`
-4. Relevant API route tests
-
-Constraint: do not break the in-memory fallback unless the user explicitly approves that change.
-
----
-
-## Validation Commands
-
-Run the smallest useful set for the area changed.
-
-```bash
-npm run lint
-npm run test
-npm run e2e
-npm run typecheck
-npm run build
-```
-
-Targeted per-file checks:
-
-```bash
-npm run test -- src/lib/data.test.ts
-npm run test -- src/app/api/matches/route.test.ts
-npm run test -- src/app/api/scoreboard/route.test.ts
-npm run test -- src/components/dashboard.test.tsx
-npm run test -- src/components/login/login-screen.test.tsx
-npm run test -- src/components/ui/composition.test.tsx
-npm run test -- src/lib/auth-validation.test.ts
-```
-
-Database commands (require `DATABASE_URL`):
-
-```bash
-npm run prisma:generate
-npm run prisma:deploy
-npm run prisma:seed
-```
-
-Notes:
-- `postinstall` runs `prisma generate` automatically
-- If you change API shape, verify the calling UI
-- If you change routing, verify `/`, `/login`, and `/scoreboard`
-
+7. Did you update docs only where behavior actually changed — no preemptive edits?

--- a/.claude/rules/ui-components.md
+++ b/.claude/rules/ui-components.md
@@ -7,9 +7,27 @@ paths:
 
 ## Layer Hierarchy
 
-- Three layers: `ui/` (shadcn primitives), `primitives/` (domain reusables like StatTile, SectionHeader), and feature directories (`dashboard/`, `login/`, `authenticated/`). Feature directories import from `ui/` and `primitives/` but never from other feature directories.
+- Three layers: `ui/` (shadcn primitives), `primitives/` (domain reusables like StatTile, SectionHeader), and feature directories (`dashboard/`, `login/`, `authenticated/`).
+- Feature directories import from `ui/` and `primitives/` but never from other feature directories.
+- **Why:** Cross-feature imports create hidden coupling that makes components hard to move or delete independently.
 
 ## CVA Variants
 
-- Use `cva()` at module scope for any component with visual variants; apply via variant props with semantic design tokens (`bg-frontend-soft`, `border-gold`). Combine with `cn()` from `@/lib/utils` for conditional merging. Components without variants do not need CVA.
+- Use `cva()` at module scope for any component with visual variants; apply via variant props with semantic design tokens (`bg-frontend-soft`, `border-gold`).
+- Combine with `cn()` from `@/lib/utils` for conditional class merging.
+- Components without variants do not need CVA.
 
+## Theme Changes
+
+When modifying tokens, CSS variables, or the theme system, read `techspec/theme-system.md` before editing.
+
+## Styling Constraints
+
+- Use semantic design tokens — no arbitrary Tailwind values (`[#abc123]`, `[var(--some-token)]`). **Why:** Arbitrary values bypass the theme system and break dark/light mode consistency.
+- Use native token classes (`rounded-xl`, `shadow-brand`) over inline style attributes.
+- Never use `style={{}}` for values that have a token equivalent.
+
+## Imports
+
+- Always import from `@/` alias — no relative `../` paths.
+- Named exports everywhere except Next.js page and layout files.


### PR DESCRIPTION
## O que muda

- Adiciona `paths` frontmatter em `auth.md`, `domain.md` e `ui-components.md` — regras agora carregam apenas no contexto relevante
- Adiciona explicações **Why** em todos os arquivos de rules para ajudar o agente em casos de borda
- Remove task routing guide e validation commands de `safe-change.md` (eram duplicações do CLAUDE.md e de outros arquivos); safe-change.md fica focado só no checklist
- Distribui ponteiros para docs em `techspec/` nos arquivos corretos (`architecture.md`, `ui-components.md`, `safe-change.md`)
- Adiciona regras de import e styling constraints em `ui-components.md`

## Como testar

- Revisar cada arquivo de rules para verificar que o conteúdo está correto e sem duplicações
- Confirmar que `safe-change.md` está focado apenas no checklist de segurança