### PR TITLE
ci: add path filters to skip workflows on non-source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,32 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'prisma/**'
+              - 'middleware.ts'
+              - 'next.config.*'
+              - 'tsconfig*.json'
+              - 'vitest.config.*'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/ci.yml'
+
   quality:
     name: CI
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,8 +14,29 @@ permissions:
   security-events: write
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            src:
+              - 'src/**'
+              - 'prisma/**'
+              - 'middleware.ts'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/codeql.yml'
+
   analyze:
     name: CodeQL
+    needs: changes
+    if: needs.changes.outputs.src == 'true' || github.event_name == 'schedule'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,8 +8,25 @@ permissions:
   pull-requests: read
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            packages:
+              - 'package.json'
+              - 'package-lock.json'
+
   dependency-review:
     name: Dependency Review
+    needs: changes
+    if: needs.changes.outputs.packages == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,16 @@ name: E2E
 
 on:
   pull_request:
+    paths:
+      - 'src/**'
+      - 'prisma/**'
+      - 'middleware.ts'
+      - 'next.config.*'
+      - 'tsconfig*.json'
+      - 'playwright.config.*'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/e2e.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## O que muda

- **CI**: adiciona job `Detect changes` com `dorny/paths-filter` — o job `CI` só roda quando arquivos de source mudam (`src/**`, `prisma/**`, configs, `package*.json`). Quando pulado via `if:`, reporta status "Skipped" que conta como passing nos required checks
- **E2E**: usa `paths:` direto no trigger (não é required check) — só roda quando source mudar
- **CodeQL**: mesmo padrão do CI com `dorny/paths-filter` — exceção: `schedule` (weekly) sempre roda independente de paths
- **Dependency Review**: só roda quando `package.json` ou `package-lock.json` mudam

## Paths que disparam CI/CodeQL

```
src/**  •  prisma/**  •  middleware.ts
next.config.*  •  tsconfig*.json  •  vitest.config.*
package.json  •  package-lock.json  •  .github/workflows/ci.yml
```

## Paths que NÃO disparam CI

```
.claude/**  •  docs/**  •  techspec/**  •  *.md  •  public/**
```

## Como testar

- Abrir PR com mudança apenas em `.claude/` ou `docs/` → CI, CodeQL e E2E devem aparecer como "Skipped"
- Abrir PR com mudança em `src/` → todos os workflows devem rodar normalmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)