### PR TITLE
docs: expandir roadmap com proximas etapas e prioridades revisadas

### DIFF
--- a/techspec/roadmap.md
+++ b/techspec/roadmap.md
@@ -10,6 +10,8 @@ Organizar os proximos passos tecnicos do projeto sem misturar backlog futuro com
 - A UI principal ja usa `Tailwind CSS` com primitives locais no estilo `shadcn/ui`
 - Auth.js por credenciais ja protege a shell autenticada em `/dashboard`, `/times`, `/ranking`, `/profile`, `/settings` e as APIs do placar
 - O cadastro inicial de usuarios ja existe via Postgres
+- A pagina de perfil ja existe com edicao de `displayName`
+- O campo `note` ja e exposto na UI tanto na criacao de partida quanto no historico
 - O dominio continua fixo em dois times globais
 
 ## Proximos passos priorizados
@@ -18,9 +20,6 @@ Organizar os proximos passos tecnicos do projeto sem misturar backlog futuro com
 
 Prioridade: alta
 
-- O rate limit de auth ja foi implementado com estado persistido em Prisma
-- A base de configuracao segura de `NEXTAUTH_SECRET` ja esta endurecida no codigo
-- A operacao sob HTTPS e cookies seguros ja esta tratada no runtime de auth
 - Priorizar testes integrados com Prisma real para auth e scoreboard
 - Confirmar no backend qualquer regra de permissao futura; nao depender apenas da UI
 
@@ -28,7 +27,15 @@ Nota:
 - a base operacional de repositorio, CI, CodeQL, Dependabot e review de dependencias agora esta documentada em `github-operations.md`
 - os proximos passos aqui ficam restritos a gaps ainda nao implementados no codigo ou na configuracao
 
-### 2. Cobertura E2E minima
+### 2. Rate limit na API de matches
+
+Prioridade: alta
+
+- A rota `POST /api/matches` nao tem protecao contra spam — multiplos registros podem ser enviados rapidamente
+- O modelo `AuthRateLimit` e o padrao de rate limit ja existem no projeto e podem ser reaproveitados
+- Implementar por IP ou por usuario autenticado, alinhado com o padrao do auth
+
+### 3. Cobertura E2E minima
 
 Prioridade: media
 
@@ -39,11 +46,79 @@ Prioridade: media
 - Avaliar `SonarQube Cloud` para code smells e quality gate de maintainability
 - Manter contratos de API e fluxo da UI sincronizados em qualquer evolucao
 
-### 3. Expansao de dominio
+### 4. Snackbars / Toast de feedback
+
+Prioridade: media
+
+- Adicionar feedback visual para acoes do usuario: registrar partida, salvar perfil, erros de API
+- Instalar cedo pois e infraestrutura de UX usada por todos os fluxos futuros
+- shadcn/ui disponibiliza o `Sonner` como componente de toast pronto para uso
+
+### 5. Exclusao ou desfazer de partida
+
+Prioridade: media
+
+- Nao existe forma de remover um registro incorreto; uma vez registrada, a partida e permanente
+- Opcao recomendada: soft delete com janela curta de tempo (ex: 30 segundos com botao "desfazer")
+- Nao abrir CRUD completo de partidas — apenas reverter o ultimo registro do usuario autenticado
+- Requer nova rota de API e verificacao de ownership da partida no backend
+
+### 6. Evolucao do schema de User
+
+Prioridade: media
+
+- Novos campos candidatos no modelo `User`:
+  - `teamId` — vinculo com um dos dois times fixos
+  - `avatarUrl` — foto de perfil
+  - `bio` — campo livre curto
+- O `/profile` ja existe mas edita apenas `displayName`; com mais campos a pagina ganha substancia real
+- Qualquer adicao de campo requer migracao Prisma + atualizacao do `ProfileResponse` e da API
+
+### 7. Adocao de times (user <-> team)
+
+Prioridade: media (depende do item 6)
+
+- Permitir que cada usuario escolha seu time (`frontend` ou `backend`) no perfil ou no cadastro
+- Abre caminho para o `/times` sair de placeholder e mostrar membros por time
+- Futuramente permite filtrar partidas ou estatisticas por membro
+- Os ids de time continuam fixos em `constants.ts`; nao generalizar para multi-team
+
+### 8. Troca de senha
+
+Prioridade: baixa
+
+- Funcionalidade natural para o `/settings`, que hoje e placeholder
+- Nao requer mudanca de schema — apenas nova rota de API com validacao de senha atual e hash da nova
+- Pode ser implementado de forma independente antes do `/settings` estar totalmente funcional
+
+### 9. Paginacao no historico de partidas
+
+Prioridade: baixa
+
+- `getScoreboard()` busca todas as partidas sem limite — com o tempo o volume cresce
+- Introducir paginacao ou limite com "ver mais" no `RecentMatchesCard` seria preventivo
+- O calculo do placar deve continuar derivado de todas as partidas; apenas a exibicao e paginada
+
+### 10. Pagina /times funcional
+
+Prioridade: futura (depende do item 7)
+
+- Substituir o placeholder atual por view real com membros de cada time e estatisticas
+- So iniciar apos adocao de times estar implementada e estavel
+
+### 11. Paginas /ranking e /settings funcionais
 
 Prioridade: futura
 
-- So iniciar depois de fechar os gaps operacionais do v1
+- `/ranking`: historico de partidas com possibilidade de filtros e evolucao do placar ao longo do tempo
+- `/settings`: preferencias de usuario (tema, notificacoes); troca de senha pode vir antes via item 8
+- Ambas sao placeholders atualmente; podem evoluir de forma independente
+
+### 12. Expansao de dominio
+
+Prioridade: futura
+
+- So iniciar depois de fechar os gaps operacionais do v1 e apos os itens anteriores
 - Escopo potencial:
   - ligas ou workspaces
   - times proprios


### PR DESCRIPTION
## O que muda

- Snapshot do estado atual atualizado: adicionado que `/profile` está implementado e que o campo `note` já é exposto na UI
- Removidos da seção 1 três bullets que descreviam trabalho já concluído (violavam a regra de uso do roadmap)
- Removido item incorreto sobre `note` não estar exposto — já está implementado em criação e histórico
- Adicionados 4 novos itens: rate limit em `/api/matches`, snackbars/toast, exclusão/desfazer de partida, troca de senha e paginação do histórico
- Todos os itens reordenados e priorizados: alta / média / baixa / futura

## Como testar

- Revisar `techspec/roadmap.md` e confirmar que o snapshot reflete o estado atual do código
- Verificar que nenhum item listado como "próximo passo" já foi implementado