### PR TITLE
fix: mover padding do layout para o app-shell

### DIFF
--- a/src/components/authenticated/app-shell.tsx
+++ b/src/components/authenticated/app-shell.tsx
@@ -346,7 +346,7 @@ export function AppShell({ user, children }: AppShellProps) {
             </Button>
           </header>
 
-          <div className="min-w-0 flex-1">{children}</div>
+          <div className="min-w-0 flex-1 px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">{children}</div>
         </div>
       </div>
 

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -208,7 +208,7 @@ export function Dashboard() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
+    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6">
       <DashboardHero
         loading={loading}
         scoreboard={scoreboard}


### PR DESCRIPTION
## O que muda

- Adiciona `px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8` no wrapper de conteúdo do `AppShell`, garantindo espaçamento consistente em todas as páginas autenticadas
- Remove o padding duplicado do `<main>` do `Dashboard` (mantém apenas `mx-auto max-w-7xl` para controle de largura)

## Como testar

- Acesse `/dashboard` e verifique que o conteúdo mantém o mesmo espaçamento de antes
- Acesse `/profile` e verifique que o conteúdo não está mais encostado nas bordas
- Acesse `/times`, `/ranking` e `/settings` e confirme o espaçamento consistente entre todas as páginas
- Teste em mobile (< 640px) e verifique o espaçamento responsivo