### PR TITLE
fix(ranking): melhora layout, tipografia e espaçamento da tela de placar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ yarn-error.log*
 
 # worktrees
 .worktrees
+
+.codex

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/ranking/podium-card.tsx
+++ b/src/components/ranking/podium-card.tsx
@@ -1,36 +1,114 @@
 import Link from "next/link";
+import { Medal, Trophy } from "lucide-react";
 
 import { StatTile } from "@/components/primitives/stat-tile";
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import type { RankedTeam } from "@/lib/ranking";
 
-const PODIUM_BADGES: Record<number, string> = {
-  1: "🏆 1º Lugar",
-  2: "🥈 2º Lugar",
-  3: "🥉 3º Lugar",
-};
+function getRankConfig(rank: number) {
+  if (rank === 1)
+    return {
+      icon: <Trophy className="size-3.5 shrink-0 text-gold" />,
+      label: "1º Lugar",
+      cardClass: "border-gold/50",
+      hoverClass: "hover:shadow-lg hover:shadow-gold/30",
+      accentStrip: true,
+      rankNumClass: "text-gold/15",
+    };
+  if (rank === 2)
+    return {
+      icon: <Medal className="size-3.5 shrink-0 text-muted-foreground" />,
+      label: "2º Lugar",
+      cardClass: "border-border-strong",
+      hoverClass: "hover:shadow-md hover:shadow-foreground/15",
+      accentStrip: false,
+      rankNumClass: "text-muted-foreground/10",
+    };
+  if (rank === 3)
+    return {
+      icon: <Medal className="size-3.5 shrink-0 text-gold/70" />,
+      label: "3º Lugar",
+      cardClass: "border-border-strong",
+      hoverClass: "hover:shadow-md hover:shadow-foreground/15",
+      accentStrip: false,
+      rankNumClass: "text-muted-foreground/10",
+    };
+  return {
+    icon: null,
+    label: `#${rank}`,
+    cardClass: "border-border",
+    hoverClass: "hover:shadow-sm",
+    accentStrip: false,
+    rankNumClass: "text-muted-foreground/10",
+  };
+}
 
 export function PodiumCard({ team }: { team: RankedTeam }) {
+  const config = getRankConfig(team.rank);
+  const streakLabel =
+    team.currentStreak.type === "win"
+      ? `${team.currentStreak.count}V`
+      : team.currentStreak.type === "loss"
+        ? `${team.currentStreak.count}D`
+        : "-";
+
   return (
     <Link href={`/times/${team.id}`} className="block focus-visible:outline-none">
-      <Card className="h-full border-border-strong bg-surface-emphasis transition hover:-translate-y-1 hover:shadow-md hover:shadow-gold/35">
-        <CardHeader className="space-y-3">
-          <Badge className="w-fit">{PODIUM_BADGES[team.rank] ?? `#${team.rank}`}</Badge>
-          <CardTitle className="title">{team.name}</CardTitle>
+      <Card
+        className={cn(
+          "h-full cursor-pointer overflow-hidden bg-surface-emphasis transition hover:-translate-y-1",
+          config.cardClass,
+          config.hoverClass,
+        )}
+      >
+        {/* Gold accent strip — rank 1 only; overflow-hidden on Card clips corners */}
+        {config.accentStrip && (
+          <div className="h-0.5 bg-gold-gradient" />
+        )}
+
+        {/* Header: rank badge + team name + decorative rank number */}
+        <CardHeader className="flex-row items-start justify-between p-4 pb-3">
+          <div className="flex flex-col gap-1.5">
+            <Badge className="flex w-fit items-center gap-1.5">
+              {config.icon}
+              {config.label}
+            </Badge>
+            <p className="text-base font-bold leading-snug">{team.name}</p>
+          </div>
+          <span
+            className={cn(
+              "select-none font-black leading-none tabular-nums text-5xl",
+              config.rankNumClass,
+            )}
+            aria-hidden
+          >
+            {team.rank}
+          </span>
         </CardHeader>
-        <CardContent className="grid gap-3 sm:grid-cols-2">
-          <StatTile label="Vitórias" value={team.wins} className="rounded-md p-3" />
-          <StatTile label="Derrotas" value={team.losses} className="rounded-md p-3" />
+
+        {/* Stats — divided grid via StatTile with border/bg stripped */}
+        <CardContent className="grid grid-cols-2 divide-x divide-y divide-border border-t border-border">
+          <StatTile
+            label="Vitórias"
+            value={team.wins}
+            className="rounded-none border-0 bg-transparent p-3"
+          />
+          <StatTile
+            label="Derrotas"
+            value={team.losses}
+            className="rounded-none border-0 bg-transparent p-3"
+          />
           <StatTile
             label="Taxa de Vitória"
             value={`${team.winRate.toFixed(1)}%`}
-            className="rounded-md p-3"
+            className="rounded-none border-0 bg-transparent p-3"
           />
           <StatTile
-            label="Sequência Atual"
-            value={`${team.currentStreak.count} ${team.currentStreak.type === "win" ? "W" : team.currentStreak.type === "loss" ? "L" : "-"}`}
-            className="rounded-md p-3"
+            label="Sequência"
+            value={streakLabel}
+            className="rounded-none border-0 bg-transparent p-3"
           />
         </CardContent>
       </Card>

--- a/src/components/ranking/ranking-view.tsx
+++ b/src/components/ranking/ranking-view.tsx
@@ -1,4 +1,3 @@
-import { SectionHeader } from "@/components/primitives/section-header";
 import { PeriodTabs } from "@/components/ranking/period-tabs";
 import { PodiumCard } from "@/components/ranking/podium-card";
 import { StandingsRow } from "@/components/ranking/standings-row";
@@ -25,11 +24,10 @@ export function RankingView({
   if (mode === "unavailable") {
     return (
       <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-        <SectionHeader
-          eyebrow="Ranking"
-          title="Placar de times"
-          description="Ranking indisponível em modo de desenvolvimento"
-        />
+        <div>
+          <p className="label-wide text-muted-foreground">Ranking</p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
+        </div>
       </main>
     );
   }
@@ -37,6 +35,10 @@ export function RankingView({
   if (teams.length === 0) {
     return (
       <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="mb-6">
+          <p className="label-wide text-muted-foreground">Ranking</p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
+        </div>
         {/* per D-02, D-12: both filter groups remain visible in empty state */}
         <TypeTabs activeType={activeType} activePeriod={activePeriod} />
         <div className="mt-4">
@@ -66,30 +68,30 @@ export function RankingView({
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-      <SectionHeader
-        eyebrow="Ranking"
-        title="Placar de times"
-        description="Classificação ao vivo baseada no histórico de partidas."
-      />
-      {/* per D-02, D-12: type and period filters coexist */}
-      <div className="mt-6">
-        <TypeTabs activeType={activeType} activePeriod={activePeriod} />
+      <div className="mb-6">
+        <p className="label-wide text-muted-foreground">Ranking</p>
+        <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
       </div>
+      {/* per D-02, D-12: type and period filters coexist */}
+      <TypeTabs activeType={activeType} activePeriod={activePeriod} />
       <div className="mt-4">
         <PeriodTabs activePeriod={activePeriod} activeType={activeType} />
       </div>
 
-      <section className="mt-6 grid gap-4 lg:grid-cols-3">
+      <section aria-label="Pódio" className="mt-6 grid gap-4 lg:grid-cols-3">
         {podium.map((team) => (
           <PodiumCard key={team.id} team={team} />
         ))}
       </section>
 
       {rest.length > 0 ? (
-        <section className="mt-6 grid gap-3">
-          {rest.map((team) => (
-            <StandingsRow key={team.id} team={team} />
-          ))}
+        <section aria-label="Classificação" className="mt-8">
+          <p className="caption mb-3 text-muted-foreground">Classificação</p>
+          <div className="grid gap-2">
+            {rest.map((team) => (
+              <StandingsRow key={team.id} team={team} />
+            ))}
+          </div>
         </section>
       ) : null}
     </main>

--- a/src/components/ranking/standings-row.tsx
+++ b/src/components/ranking/standings-row.tsx
@@ -1,29 +1,84 @@
 import Link from "next/link";
 
+import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import type { RankedTeam } from "@/lib/ranking";
 
 export function StandingsRow({ team }: { team: RankedTeam }) {
+  const isWinStreak = team.currentStreak.type === "win";
+  const isLossStreak = team.currentStreak.type === "loss";
+
+  const streak = isWinStreak
+    ? `${team.currentStreak.count}V`
+    : isLossStreak
+      ? `${team.currentStreak.count}D`
+      : "-";
+
   return (
     <Link
       href={`/times/${team.id}`}
-      className="grid gap-3 rounded-lg border border-border bg-surface p-4 transition hover:shadow-sm hover:shadow-foreground/20 md:grid-cols-[auto_1fr_auto_auto_auto_auto_auto]"
+      className="cursor-pointer rounded-lg border border-border bg-surface transition hover:border-border-strong hover:shadow-sm hover:shadow-foreground/20"
     >
-      <p className="label-wide text-muted-foreground">#{team.rank}</p>
-      <div>
-        <p className="font-semibold">{team.name}</p>
+      {/* Desktop layout */}
+      <div className="hidden items-center gap-4 px-4 py-3 md:grid md:grid-cols-[2rem_1fr_auto_5rem_5rem_6rem_6rem]">
+        <p className="label-wide text-center text-muted-foreground">#{team.rank}</p>
+        <p className="truncate font-semibold">{team.name}</p>
+        <Badge variant="outline" className="justify-self-start">
+          {team.type === "solo" ? "Solo" : "Duplas"}
+        </Badge>
+        <div className="text-center">
+          <p className="caption text-muted-foreground">V</p>
+          <p className="text-sm font-medium">{team.wins}</p>
+        </div>
+        <div className="text-center">
+          <p className="caption text-muted-foreground">D</p>
+          <p className="text-sm font-medium">{team.losses}</p>
+        </div>
+        <div className="text-center">
+          <p className="caption text-muted-foreground">Taxa</p>
+          <p className="text-sm font-medium">{team.winRate.toFixed(1)}%</p>
+        </div>
+        <div className="text-center">
+          <p className="caption text-muted-foreground">Sequência</p>
+          <p
+            className={cn(
+              "text-sm font-medium",
+              isWinStreak && "text-primary",
+              isLossStreak && "text-danger",
+            )}
+          >
+            {streak} · {team.totalMatches}j
+          </p>
+        </div>
       </div>
-      <Badge variant="outline">{team.type === "solo" ? "Solo" : "Duplas"}</Badge>
-      <p className="text-sm">{team.wins}</p>
-      <p className="text-sm">{team.losses}</p>
-      <p className="text-sm">{team.winRate.toFixed(1)}%</p>
-      <p className="text-sm">
-        {team.currentStreak.count}
-        {" "}
-        {team.currentStreak.type === "win" ? "W" : team.currentStreak.type === "loss" ? "L" : "-"}
-        {" · "}
-        {team.totalMatches}j
-      </p>
+
+      {/* Mobile layout */}
+      <div className="flex items-center gap-3 px-4 py-3 md:hidden">
+        <p className="label-wide w-6 shrink-0 text-center text-muted-foreground">
+          #{team.rank}
+        </p>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold">{team.name}</p>
+          <div className="mt-1 flex items-center gap-2">
+            <Badge variant="outline" className="text-xs">
+              {team.type === "solo" ? "Solo" : "Duplas"}
+            </Badge>
+            <p className="text-xs text-muted-foreground">
+              {team.wins}V · {team.losses}D · {team.winRate.toFixed(1)}%
+            </p>
+          </div>
+        </div>
+        <p
+          className={cn(
+            "shrink-0 text-xs font-medium",
+            isWinStreak && "text-primary",
+            isLossStreak && "text-danger",
+            !isWinStreak && !isLossStreak && "text-muted-foreground",
+          )}
+        >
+          {streak}
+        </p>
+      </div>
     </Link>
   );
 }


### PR DESCRIPTION
## O que muda

- **PodiumCard**: tipografia corrigida — remove `CardTitle` com clamp 3–4.8rem, usa `text-base font-bold` diretamente; padding explícito em `CardHeader` (`p-4 pb-3`) e grid dividido em `CardContent`; ícones Lucide coloridos (`Trophy` dourado no 1º, `Medal` muted no 2º, `Medal` gold/70 no 3º); strip dourado `h-0.5 bg-gold-gradient` no rank 1; `overflow-hidden` no Card para border-radius correto em todos os cantos
- **StandingsRow**: adiciona `cursor-pointer`; layout mobile com Badge de tipo + métricas inline; colorização de sequência (`text-primary` para vitórias, `text-danger` para derrotas); desktop com colunas bem definidas e label de partidas totais
- **RankingView**: header compacto no padrão da tela de Times (`label-wide` eyebrow + `text-xl font-semibold tracking-tight`); remove wrapper `mt-6` ao redor de `TypeTabs` para igualar espaçamento visual entre título e navbar

## Como testar

- [ ] Acessar `/ranking` com times e partidas cadastradas
- [ ] Verificar pódio: cards com padding correto, texto legível, ícones coloridos (ouro/prata/bronze)
- [ ] Verificar que o 1º lugar tem a faixa dourada no topo e que os cantos inferiores têm border-radius
- [ ] Verificar listagem: colunas alinhadas no desktop, layout mobile com badge + streak colorido
- [ ] Comparar espaçamento entre título e navbar com a tela de `/times` — devem ser equivalentes

🤖 Generated with [Claude Code](https://claude.com/claude-code)