### PR TITLE
feat: enrich ranking podium context

### DIFF
--- a/src/components/ranking/podium-card.tsx
+++ b/src/components/ranking/podium-card.tsx
@@ -53,6 +53,8 @@ export function PodiumCard({ team }: { team: RankedTeam }) {
       : team.currentStreak.type === "loss"
         ? `${team.currentStreak.count}D`
         : "-";
+  const membersLabel = team.memberNames.join(" • ");
+  const typeLabel = team.type === "solo" ? "Solo" : "Dupla";
 
   return (
     <Link href={`/times/${team.id}`} className="block focus-visible:outline-none">
@@ -75,7 +77,15 @@ export function PodiumCard({ team }: { team: RankedTeam }) {
               {config.icon}
               {config.label}
             </Badge>
-            <p className="text-base font-bold leading-snug">{team.name}</p>
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-base font-bold leading-snug">{team.name}</p>
+              <Badge variant="outline" className="text-[11px]">
+                {typeLabel}
+              </Badge>
+            </div>
+            {membersLabel ? (
+              <p className="text-sm leading-snug text-muted-foreground">{membersLabel}</p>
+            ) : null}
           </div>
           <span
             className={cn(

--- a/src/components/ranking/ranking-view.test.tsx
+++ b/src/components/ranking/ranking-view.test.tsx
@@ -33,6 +33,7 @@ const teams: RankedTeam[] = [
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     members: [],
+    memberNames: ["Ana", "Bruno"],
     teamId: "team-1",
     wins: 3,
     losses: 1,
@@ -51,6 +52,7 @@ const teams: RankedTeam[] = [
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     members: [],
+    memberNames: ["Carla"],
     teamId: "team-2",
     wins: 4,
     losses: 2,
@@ -69,6 +71,7 @@ const teams: RankedTeam[] = [
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     members: [],
+    memberNames: ["Davi", "Elisa"],
     teamId: "team-3",
     wins: 2,
     losses: 1,
@@ -87,6 +90,7 @@ const teams: RankedTeam[] = [
     createdAt: "2026-01-01T00:00:00.000Z",
     updatedAt: "2026-01-01T00:00:00.000Z",
     members: [],
+    memberNames: ["Fábio", "Gabi"],
     teamId: "team-4",
     wins: 1,
     losses: 3,
@@ -116,6 +120,27 @@ describe("RankingView", () => {
 
     expect(within(standings).getAllByText("Time Quatro")).toHaveLength(2);
     expect(within(standings).queryByText("Time Cinco")).not.toBeInTheDocument();
+  });
+
+  it("renders member display names as podium subtitle", () => {
+    render(<RankingView teams={teams} activeType="all" mode="available" />);
+
+    expect(screen.getByText("Ana • Bruno")).toBeInTheDocument();
+    expect(screen.getByText("Carla")).toBeInTheDocument();
+    expect(screen.getByText("Davi • Elisa")).toBeInTheDocument();
+    expect(screen.queryByText("Fábio • Gabi")).not.toBeInTheDocument();
+  });
+
+  it("renders a team type badge on podium cards", () => {
+    render(<RankingView teams={teams} activeType="all" mode="available" />);
+
+    const teamOneLink = screen.getAllByRole("link").find((link) => link.getAttribute("href") === "/times/team-1");
+    const teamTwoLink = screen.getAllByRole("link").find((link) => link.getAttribute("href") === "/times/team-2");
+
+    expect(teamOneLink).toBeDefined();
+    expect(teamTwoLink).toBeDefined();
+    expect(within(teamOneLink!).getByText("Dupla")).toBeInTheDocument();
+    expect(within(teamTwoLink!).getByText("Solo")).toBeInTheDocument();
   });
 
   it("renders available empty-state copy", () => {

--- a/src/lib/ranking.test.ts
+++ b/src/lib/ranking.test.ts
@@ -43,6 +43,18 @@ describe("listAllTeamsWithStats", () => {
     expect(mockTeamFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { status: "active", type: "solo" },
+        include: {
+          members: {
+            include: {
+              user: {
+                select: {
+                  username: true,
+                  displayName: true,
+                },
+              },
+            },
+          },
+        },
       }),
     );
   });
@@ -58,7 +70,18 @@ describe("listAllTeamsWithStats", () => {
         createdBy: "u1",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
         updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-        members: [],
+        members: [
+          {
+            userId: "u1",
+            joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+            user: { username: "alpha.one", displayName: "Alpha One" },
+          },
+          {
+            userId: "u2",
+            joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+            user: { username: "alpha.two", displayName: null },
+          },
+        ],
       },
       {
         id: "team-b",
@@ -68,7 +91,13 @@ describe("listAllTeamsWithStats", () => {
         createdBy: "u1",
         createdAt: new Date("2026-01-01T00:00:00.000Z"),
         updatedAt: new Date("2026-01-01T00:00:00.000Z"),
-        members: [],
+        members: [
+          {
+            userId: "u3",
+            joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+            user: { username: "beta.one", displayName: "Beta One" },
+          },
+        ],
       },
     ]);
     mockMatchFindMany.mockResolvedValueOnce([
@@ -86,6 +115,7 @@ describe("listAllTeamsWithStats", () => {
     const result = await listAllTeamsWithStats();
 
     expect(result.map((team) => team.id)).toEqual(["team-a", "team-b"]);
+    expect(result[0]?.memberNames).toEqual(["Alpha One", "alpha.two"]);
     expect(result[0]?.rank).toBe(1);
     expect(result[1]?.rank).toBe(2);
   });

--- a/src/lib/ranking.ts
+++ b/src/lib/ranking.ts
@@ -4,7 +4,7 @@ import { resolvePeriodWindow } from "@/lib/time-period";
 import type { MatchRecord, RankingPeriod, TeamRecord } from "@/lib/types";
 import type { TeamStats } from "@/lib/stats";
 
-export type RankedTeam = TeamRecord & TeamStats & { rank: number };
+export type RankedTeam = TeamRecord & TeamStats & { rank: number; memberNames: string[] };
 
 function hasDatabaseUrl() {
   return Boolean(process.env.DATABASE_URL);
@@ -18,8 +18,12 @@ function normalizeTeam(team: {
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
-  members: { userId: string; joinedAt: Date }[];
-}): TeamRecord {
+  members: {
+    userId: string;
+    joinedAt: Date;
+    user: { username: string; displayName: string | null };
+  }[];
+}): TeamRecord & { memberNames: string[] } {
   return {
     id: team.id,
     name: team.name,
@@ -32,6 +36,7 @@ function normalizeTeam(team: {
       userId: member.userId,
       joinedAt: member.joinedAt.toISOString(),
     })),
+    memberNames: team.members.map((member) => member.user.displayName ?? member.user.username),
   };
 }
 
@@ -63,7 +68,18 @@ export async function listAllTeamsWithStats(
 
   const teamRows = await prisma.team.findMany({
     where: { status: "active", ...(type ? { type } : {}) },
-    include: { members: true },
+    include: {
+      members: {
+        include: {
+          user: {
+            select: {
+              username: true,
+              displayName: true,
+            },
+          },
+        },
+      },
+    },
   });
 
   const teams = teamRows.map(normalizeTeam);


### PR DESCRIPTION
  ## Summary
  - show team member display names as a subtitle on podium cards
  - add a small Solo/Dupla badge next to the podium team name
  - extend ranking payload/tests so podium cards receive member names safely

  ## Verification
  - npm test -- --run src/components/ranking/ranking-view.test.tsx src/lib/ranking.test.ts