### PR TITLE
feat: show last five results in ranking

### DIFF
--- a/src/components/ranking/ranking-view.test.tsx
+++ b/src/components/ranking/ranking-view.test.tsx
@@ -41,6 +41,7 @@ const teams: RankedTeam[] = [
     currentStreak: { type: "win", count: 2 },
     longestStreak: { type: "win", count: 2 },
     totalMatches: 4,
+    lastFiveResults: ["win", "win", "loss", "win"],
     rank: 1,
   },
   {
@@ -60,6 +61,7 @@ const teams: RankedTeam[] = [
     currentStreak: { type: "win", count: 1 },
     longestStreak: { type: "win", count: 2 },
     totalMatches: 6,
+    lastFiveResults: ["win", "loss", "loss", "win", "win"],
     rank: 2,
   },
   {
@@ -79,6 +81,7 @@ const teams: RankedTeam[] = [
     currentStreak: { type: "loss", count: 1 },
     longestStreak: { type: "win", count: 2 },
     totalMatches: 3,
+    lastFiveResults: ["loss", "win", "win"],
     rank: 3,
   },
   {
@@ -98,6 +101,7 @@ const teams: RankedTeam[] = [
     currentStreak: { type: "loss", count: 2 },
     longestStreak: { type: "win", count: 1 },
     totalMatches: 4,
+    lastFiveResults: ["loss", "loss", "win", "loss"],
     rank: 4,
   },
 ];
@@ -165,6 +169,20 @@ describe("RankingView", () => {
     const links = screen.getAllByRole("link");
     expect(links.some((link) => link.getAttribute("href") === "/times/team-1")).toBe(true);
     expect(links.some((link) => link.getAttribute("href") === "/times/team-4")).toBe(true);
+  });
+
+  it("renders the last 5 matches as visual indicators in standings rows", () => {
+    render(<RankingView teams={teams} activeType="all" mode="available" />);
+
+    const history = screen.getAllByLabelText("Últimas 5 partidas de Time Quatro");
+    expect(history).toHaveLength(2);
+
+    const desktopHistory = history[0]!;
+    expect(within(desktopHistory).getByLabelText("Partida 1: derrota")).toBeInTheDocument();
+    expect(within(desktopHistory).getByLabelText("Partida 2: derrota")).toBeInTheDocument();
+    expect(within(desktopHistory).getByLabelText("Partida 3: vitória")).toBeInTheDocument();
+    expect(within(desktopHistory).getByLabelText("Partida 4: derrota")).toBeInTheDocument();
+    expect(within(desktopHistory).getByLabelText("Partida 5: sem histórico")).toBeInTheDocument();
   });
 
   it("empty state in mode=available keeps both type and period tabs visible", () => {

--- a/src/components/ranking/standings-row.tsx
+++ b/src/components/ranking/standings-row.tsx
@@ -4,16 +4,34 @@ import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import type { RankedTeam } from "@/lib/ranking";
 
+function RecentResultsDots({ results, teamName }: { results: RankedTeam["lastFiveResults"]; teamName: string }) {
+  const slots = [...results, ...Array.from({ length: Math.max(0, 5 - results.length) }, () => "none" as const)];
+
+  return (
+    <div className="flex items-center justify-center gap-1.5" aria-label={`Últimas 5 partidas de ${teamName}`}>
+      {slots.map((result, index) => (
+        <span
+          key={`${teamName}-${index}`}
+          aria-label={
+            result === "win"
+              ? `Partida ${index + 1}: vitória`
+              : result === "loss"
+                ? `Partida ${index + 1}: derrota`
+                : `Partida ${index + 1}: sem histórico`
+          }
+          className={cn(
+            "block h-2.5 w-2.5 rounded-full border",
+            result === "win" && "border-primary/70 bg-primary",
+            result === "loss" && "border-danger/70 bg-danger",
+            result === "none" && "border-border bg-surface-muted",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
 export function StandingsRow({ team }: { team: RankedTeam }) {
-  const isWinStreak = team.currentStreak.type === "win";
-  const isLossStreak = team.currentStreak.type === "loss";
-
-  const streak = isWinStreak
-    ? `${team.currentStreak.count}V`
-    : isLossStreak
-      ? `${team.currentStreak.count}D`
-      : "-";
-
   return (
     <Link
       href={`/times/${team.id}`}
@@ -39,16 +57,10 @@ export function StandingsRow({ team }: { team: RankedTeam }) {
           <p className="text-sm font-medium">{team.winRate.toFixed(1)}%</p>
         </div>
         <div className="text-center">
-          <p className="caption text-muted-foreground">Sequência</p>
-          <p
-            className={cn(
-              "text-sm font-medium",
-              isWinStreak && "text-primary",
-              isLossStreak && "text-danger",
-            )}
-          >
-            {streak} · {team.totalMatches}j
-          </p>
+          <p className="caption text-muted-foreground">Últimas 5</p>
+          <div className="mt-1 flex items-center justify-center">
+            <RecentResultsDots results={team.lastFiveResults} teamName={team.name} />
+          </div>
         </div>
       </div>
 
@@ -68,16 +80,9 @@ export function StandingsRow({ team }: { team: RankedTeam }) {
             </p>
           </div>
         </div>
-        <p
-          className={cn(
-            "shrink-0 text-xs font-medium",
-            isWinStreak && "text-primary",
-            isLossStreak && "text-danger",
-            !isWinStreak && !isLossStreak && "text-muted-foreground",
-          )}
-        >
-          {streak}
-        </p>
+        <div className="shrink-0">
+          <RecentResultsDots results={team.lastFiveResults} teamName={team.name} />
+        </div>
       </div>
     </Link>
   );

--- a/src/lib/stats.test.ts
+++ b/src/lib/stats.test.ts
@@ -61,6 +61,7 @@ describe("computeTeamStats", () => {
       expect(result.currentStreak).toEqual({ type: "none", count: 0 });
       expect(result.longestStreak).toEqual({ type: "none", count: 0 });
       expect(result.totalMatches).toBe(0);
+      expect(result.lastFiveResults).toEqual([]);
     });
   });
 
@@ -74,6 +75,7 @@ describe("computeTeamStats", () => {
       expect(result.losses).toBe(0);
       expect(result.currentStreak).toEqual({ type: "win", count: 1 });
       expect(result.longestStreak).toEqual({ type: "win", count: 1 });
+      expect(result.lastFiveResults).toEqual(["win"]);
     });
 
     it("returns 0% win rate and loss streak of 1 for single loss", () => {
@@ -85,6 +87,7 @@ describe("computeTeamStats", () => {
       expect(result.losses).toBe(1);
       expect(result.currentStreak).toEqual({ type: "loss", count: 1 });
       expect(result.longestStreak).toEqual({ type: "loss", count: 1 });
+      expect(result.lastFiveResults).toEqual(["loss"]);
     });
   });
 
@@ -105,6 +108,7 @@ describe("computeTeamStats", () => {
       expect(result.losses).toBe(30);
       expect(result.winRate).toBeCloseTo(70, 5);
       expect(result.totalMatches).toBe(100);
+      expect(result.lastFiveResults).toEqual(["win", "win", "win", "win", "win"]);
     });
   });
 
@@ -159,6 +163,21 @@ describe("computeTeamStats", () => {
       const result = computeTeamStats("team-a", matches);
       expect(result.currentStreak).toEqual({ type: "win", count: 2 });
       expect(result.longestStreak).toEqual({ type: "win", count: 2 });
+    });
+
+    it("stores up to the 5 most recent results in descending order", () => {
+      const matches: MatchRecord[] = [
+        makeMatch("m6", "team-a", "team-b", "team-a", "2026-03-26T10:00:00Z"),
+        makeMatch("m5", "team-a", "team-b", "team-b", "2026-03-25T10:00:00Z"),
+        makeMatch("m4", "team-a", "team-b", "team-a", "2026-03-24T10:00:00Z"),
+        makeMatch("m3", "team-a", "team-b", "team-b", "2026-03-23T10:00:00Z"),
+        makeMatch("m2", "team-a", "team-b", "team-a", "2026-03-22T10:00:00Z"),
+        makeMatch("m1", "team-a", "team-b", "team-b", "2026-03-21T10:00:00Z"),
+      ];
+
+      const result = computeTeamStats("team-a", matches);
+
+      expect(result.lastFiveResults).toEqual(["win", "loss", "win", "loss", "win"]);
     });
   });
 });
@@ -230,6 +249,7 @@ describe("SC-6: Zod output validation", () => {
         currentStreak: { type: "win", count: 5 },
         longestStreak: { type: "win", count: 5 },
         totalMatches: 5,
+        lastFiveResults: ["win", "win", "win", "win", "win"],
       })
     ).toThrow();
   });
@@ -244,6 +264,7 @@ describe("SC-6: Zod output validation", () => {
         currentStreak: { type: "loss", count: 5 },
         longestStreak: { type: "loss", count: 5 },
         totalMatches: 5,
+        lastFiveResults: ["loss", "loss", "loss", "loss", "loss"],
       })
     ).toThrow();
   });
@@ -258,6 +279,7 @@ describe("SC-6: Zod output validation", () => {
         currentStreak: { type: "win", count: 5 },
         longestStreak: { type: "win", count: 5 },
         totalMatches: 5,
+        lastFiveResults: ["win", "win", "win", "win", "win"],
       })
     ).toThrow();
   });
@@ -272,6 +294,7 @@ describe("SC-6: Zod output validation", () => {
         currentStreak: { type: "none", count: -1 },
         longestStreak: { type: "none", count: 0 },
         totalMatches: 0,
+        lastFiveResults: [],
       })
     ).toThrow();
   });

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -16,6 +16,7 @@ export const TeamStatsSchema = z.object({
   currentStreak: StreakSchema,
   longestStreak: StreakSchema,
   totalMatches: z.number().int().nonnegative(),
+  lastFiveResults: z.array(z.enum(["win", "loss"])).max(5),
 });
 
 export const HeadToHeadStatsSchema = z.object({
@@ -119,6 +120,9 @@ export function computeTeamStats(
   const winRate = total === 0 ? 0 : (wins / total) * 100;
 
   const { currentStreak, longestStreak } = detectStreaks(teamId, teamMatches);
+  const lastFiveResults = teamMatches
+    .slice(0, 5)
+    .map((match) => (match.winnerTeamId === teamId ? "win" : "loss"));
 
   return TeamStatsSchema.parse({
     teamId,
@@ -128,6 +132,7 @@ export function computeTeamStats(
     currentStreak,
     longestStreak,
     totalMatches: total,
+    lastFiveResults,
   });
 }
 


### PR DESCRIPTION
## O que muda
- Troca a coluna de sequencia por um historico visual das ultimas 5 partidas com dots de vitoria e derrota.
- Adiciona o campo `lastFiveResults` em `TeamStats` para derivar os ultimos resultados do time.
- Atualiza os testes de stats e ranking para cobrir o novo contrato e a renderizacao dos dots.

## Como testar
- npx vitest run src/lib/stats.test.ts src/components/ranking/ranking-view.test.tsx
- npx tsc --noEmit