### PR TITLE
feat(ui): add shared controls and refresh app surfaces

### DIFF
--- a/src/app/(authenticated)/times/page.tsx
+++ b/src/app/(authenticated)/times/page.tsx
@@ -5,6 +5,7 @@ import { Users } from "lucide-react";
 import { TeamCard } from "@/components/teams/team-card";
 import { TeamCreateForm } from "@/components/teams/team-create-form";
 import { IconCallout } from "@/components/primitives/icon-callout";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 import { getAuthenticatedUser, hasDatabaseUrl } from "@/lib/auth";
 import { listUserTeams } from "@/lib/teams";
 
@@ -41,20 +42,18 @@ export default async function TeamsPage({ searchParams }: TeamsPageProps) {
         </h1>
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        <Link
-          href="/times?tab=teams"
-          className={`rounded-pill border px-4 py-2 text-sm transition-colors ${tab === "teams" ? "border-primary bg-primary text-foreground-inverse" : "border-border bg-surface text-muted-foreground hover:border-border-strong hover:bg-surface-emphasis hover:text-foreground"}`}
-        >
-          Meus Times
-        </Link>
-        <Link
-          href="/times?tab=create"
-          className={`rounded-pill border px-4 py-2 text-sm transition-colors ${tab === "create" ? "border-primary bg-primary text-foreground-inverse" : "border-border bg-surface text-muted-foreground hover:border-border-strong hover:bg-surface-emphasis hover:text-foreground"}`}
-        >
-          Criar Novo Time
-        </Link>
-      </div>
+      <SegmentedControl aria-label="Navegação da área de times" role="navigation">
+        <SegmentedControlItem asChild active={tab === "teams"}>
+          <Link href="/times?tab=teams" aria-current={tab === "teams" ? "page" : undefined}>
+            Meus Times
+          </Link>
+        </SegmentedControlItem>
+        <SegmentedControlItem asChild active={tab === "create"}>
+          <Link href="/times?tab=create" aria-current={tab === "create" ? "page" : undefined}>
+            Criar Novo Time
+          </Link>
+        </SegmentedControlItem>
+      </SegmentedControl>
 
       <div className={`mt-6 ${tab === "teams" ? "grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]" : ""}`}>
         <section className="space-y-3">

--- a/src/components/authenticated/app-shell.tsx
+++ b/src/components/authenticated/app-shell.tsx
@@ -18,6 +18,7 @@ import {
 import { type ComponentType, type ReactNode, useMemo, useState } from "react";
 
 import { ThemeToggle } from "@/components/theme/theme-toggle";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { cn } from "@/lib/utils";
@@ -69,9 +70,11 @@ function UserAvatar({ user }: { user: SessionUser }) {
 
   return (
     <div className="relative">
-      <div className="text-sidebar-foreground flex size-11 shrink-0 items-center justify-center rounded-pill border border-sidebar-border bg-avatar-gradient text-sm font-bold uppercase tracking-label-sm">
-        {initials || "OB"}
-      </div>
+      <Avatar className="size-11 rounded-pill border-sidebar-border bg-avatar-gradient">
+        <AvatarFallback className="bg-transparent text-sidebar-foreground tracking-label-sm">
+          {initials || "OB"}
+        </AvatarFallback>
+      </Avatar>
       <span className="absolute bottom-0 right-0 size-3 rounded-full border-2 border-avatar-ring bg-status" />
     </div>
   );

--- a/src/components/dashboard/index.tsx
+++ b/src/components/dashboard/index.tsx
@@ -7,6 +7,7 @@ import { startTransition, useId, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
 import { SectionHeader } from "@/components/primitives/section-header";
 import { StatTile } from "@/components/primitives/stat-tile";
 import type { TeamRecord } from "@/lib/types";
@@ -131,7 +132,7 @@ function TeamScoreCard({
             </span>
           </div>
 
-          <textarea
+          <Textarea
             id={noteId}
             value={note}
             data-testid={`team-note-${team.id}`}
@@ -139,7 +140,7 @@ function TeamScoreCard({
             rows={3}
             disabled={isSubmitting}
             placeholder="Vale zoeira curta, sem tese de retrospectiva."
-            className="min-h-24 w-full resize-none rounded-md border border-border-strong bg-surface-emphasis px-4 py-3 text-sm text-foreground outline-none transition placeholder:text-foreground-soft focus:border-team-alpha focus:ring-2 focus:ring-team-alpha-soft disabled:cursor-not-allowed disabled:bg-surface-muted"
+            className="resize-none border-border-strong placeholder:text-foreground-soft"
             onChange={(event) => {
               onNoteChange(team.id, event.target.value);
             }}

--- a/src/components/head-to-head/head-to-head-view.tsx
+++ b/src/components/head-to-head/head-to-head-view.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter } from "next/navigation";
 
+import { Label } from "@/components/ui/label";
+import { NativeSelect } from "@/components/ui/native-select";
 import type { HeadToHeadPageData } from "@/lib/head-to-head";
 import type { TeamRecord } from "@/lib/types";
 
@@ -69,12 +71,11 @@ export function HeadToHeadView({ data }: Props) {
         <div className="grid gap-4 sm:grid-cols-2">
           {/* Team A selector */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium" htmlFor="selector-team-a">
+            <Label htmlFor="selector-team-a">
               Team A
-            </label>
-            <select
+            </Label>
+            <NativeSelect
               id="selector-team-a"
-              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm"
               value={teamAId}
               onChange={handleTeamAChange}
             >
@@ -86,17 +87,16 @@ export function HeadToHeadView({ data }: Props) {
                     {team.name} ({team.type === "solo" ? "Solo" : "Duplas"})
                   </option>
                 ))}
-            </select>
+            </NativeSelect>
           </div>
 
           {/* Team B selector */}
           <div className="space-y-1.5">
-            <label className="text-sm font-medium" htmlFor="selector-team-b">
+            <Label htmlFor="selector-team-b">
               Team B
-            </label>
-            <select
+            </Label>
+            <NativeSelect
               id="selector-team-b"
-              className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm"
               value={teamBId}
               onChange={handleTeamBChange}
             >
@@ -108,7 +108,7 @@ export function HeadToHeadView({ data }: Props) {
                     {team.name} ({team.type === "solo" ? "Solo" : "Duplas"})
                   </option>
                 ))}
-            </select>
+            </NativeSelect>
           </div>
         </div>
 

--- a/src/components/login/login-screen.tsx
+++ b/src/components/login/login-screen.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldError } from "@/components/primitives/form-field";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 import { AUTH_RATE_LIMIT_ERROR } from "@/lib/auth-rate-limit";
 import {
   getLoginFieldErrors,
@@ -48,9 +49,6 @@ const INITIAL_TOUCHED_FIELDS = {
   username: false,
   password: false,
 };
-
-const SEGMENT_BUTTON_BASE_CLASS =
-  "rounded-sm px-4 py-3 text-sm font-semibold transition disabled:cursor-not-allowed";
 
 export function LoginScreen({
   authAvailable,
@@ -292,34 +290,26 @@ export function LoginScreen({
                     </div>
                   </div>
 
-                  <div className="grid grid-cols-2 gap-3 rounded-lg border border-border bg-surface-emphasis p-2">
-                    <button
+                  <SegmentedControl className="grid grid-cols-2">
+                    <SegmentedControlItem
                       type="button"
-                      className={`${SEGMENT_BUTTON_BASE_CLASS} ${
-                        !isRegisterMode
-                          ? "bg-primary text-primary-foreground shadow-sm"
-                          : "text-muted-foreground"
-                      }`}
+                      active={!isRegisterMode}
                       onClick={() => handleModeChange("login")}
                       disabled={areControlsDisabled}
                       data-testid="login-mode-login"
                     >
                       Entrar
-                    </button>
-                    <button
+                    </SegmentedControlItem>
+                    <SegmentedControlItem
                       type="button"
-                      className={`${SEGMENT_BUTTON_BASE_CLASS} ${
-                        isRegisterMode
-                          ? "bg-primary text-primary-foreground shadow-sm"
-                          : "text-muted-foreground"
-                      }`}
+                      active={isRegisterMode}
                       onClick={() => handleModeChange("register")}
                       disabled={areControlsDisabled}
                       data-testid="login-mode-register"
                     >
                       Criar conta
-                    </button>
-                  </div>
+                    </SegmentedControlItem>
+                  </SegmentedControl>
 
                   <form className="space-y-4" onSubmit={handleSubmit}>
                     <Field>

--- a/src/components/profile/profile-edit-dialog.tsx
+++ b/src/components/profile/profile-edit-dialog.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import { Field, FieldError } from "@/components/primitives/form-field";
 import type { ProfileResponse } from "@/lib/types";
 
@@ -150,12 +151,14 @@ export function ProfileEditDialog({
           </Field>
           <Field>
             <Label htmlFor="bio">Bio</Label>
-            <Input
+            <Textarea
               id="bio"
               value={form.bio}
               onChange={(e) => updateField("bio", e.target.value)}
               placeholder="Conta um pouco sobre você"
               disabled={loading}
+              maxLength={200}
+              rows={4}
             />
             <FieldError>{errors.bio}</FieldError>
           </Field>

--- a/src/components/profile/profile-page.tsx
+++ b/src/components/profile/profile-page.tsx
@@ -13,6 +13,7 @@ import {
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { IconCallout } from "@/components/primitives/icon-callout";
 import { SectionHeader } from "@/components/primitives/section-header";
 import { StatTile } from "@/components/primitives/stat-tile";
@@ -120,7 +121,7 @@ export function ProfilePage({ data }: ProfilePageProps) {
       {/* Hero */}
       <section className="relative overflow-hidden rounded-xl border border-primary/20 bg-primary/10 p-6 lg:p-10">
         <div className="flex flex-col items-center gap-6 md:flex-row">
-          <div className="flex size-24 shrink-0 items-center justify-center rounded-full border border-border bg-muted text-2xl font-bold uppercase text-foreground overflow-hidden">
+          <Avatar className="size-24 border-border bg-muted text-2xl">
             {avatarSrc && !avatarLoadError ? (
               <Image
                 src={avatarSrc}
@@ -131,9 +132,11 @@ export function ProfilePage({ data }: ProfilePageProps) {
                 onError={() => setAvatarLoadError(true)}
               />
             ) : (
-              initials || "OB"
+              <AvatarFallback className="bg-muted text-2xl font-bold">
+                {initials || "OB"}
+              </AvatarFallback>
             )}
-          </div>
+          </Avatar>
           <div className="text-center md:text-left">
             <h2 className="text-xl font-bold">
               {editableProfile.displayName ?? editableProfile.username}

--- a/src/components/ranking/period-tabs.tsx
+++ b/src/components/ranking/period-tabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-import { cn } from "@/lib/utils";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 
 type RankingPeriod = "all" | "month" | "week";
 
@@ -28,25 +28,21 @@ export function PeriodTabs({
   }
 
   return (
-    <nav aria-label="Filtro de período" className="flex flex-wrap gap-2">
+    <SegmentedControl aria-label="Filtro de período" role="navigation">
       {TABS.map((tab) => {
         const active = tab.value === activePeriod;
         return (
-          <Link
+          <SegmentedControlItem
             key={tab.value}
-            href={buildHref(tab.value)}
-            aria-current={active ? "page" : undefined}
-            className={cn(
-              "rounded-pill border px-4 py-2 text-sm font-medium transition",
-              active
-                ? "border-primary bg-primary text-foreground-inverse"
-                : "border-border bg-surface text-muted-foreground hover:text-foreground",
-            )}
+            asChild
+            active={active}
           >
-            {tab.label}
-          </Link>
+            <Link href={buildHref(tab.value)} aria-current={active ? "page" : undefined}>
+              {tab.label}
+            </Link>
+          </SegmentedControlItem>
         );
       })}
-    </nav>
+    </SegmentedControl>
   );
 }

--- a/src/components/ranking/type-tabs.tsx
+++ b/src/components/ranking/type-tabs.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 
-import { cn } from "@/lib/utils";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 
 type RankingType = "all" | "solo" | "duo";
 
@@ -28,25 +28,21 @@ export function TypeTabs({
   }
 
   return (
-    <nav aria-label="Filtro de tipo de time" className="flex flex-wrap gap-2">
+    <SegmentedControl aria-label="Filtro de tipo de time" role="navigation">
       {TYPE_VALUES.map((tab) => {
         const active = tab.value === activeType;
         return (
-          <Link
+          <SegmentedControlItem
             key={tab.value}
-            href={buildHref(tab.value)}
-            aria-current={active ? "page" : undefined}
-            className={cn(
-              "rounded-pill border px-4 py-2 text-sm font-medium transition",
-              active
-                ? "border-primary bg-primary text-foreground-inverse"
-                : "border-border bg-surface text-muted-foreground hover:text-foreground",
-            )}
+            asChild
+            active={active}
           >
-            {tab.label}
-          </Link>
+            <Link href={buildHref(tab.value)} aria-current={active ? "page" : undefined}>
+              {tab.label}
+            </Link>
+          </SegmentedControlItem>
         );
       })}
-    </nav>
+    </SegmentedControl>
   );
 }

--- a/src/components/teams/h2h-section.tsx
+++ b/src/components/teams/h2h-section.tsx
@@ -2,9 +2,17 @@
 
 import { useMemo, useState } from "react";
 
+import { StatTile } from "@/components/primitives/stat-tile";
+import { Badge } from "@/components/ui/badge";
+import { Label } from "@/components/ui/label";
+import { NativeSelect } from "@/components/ui/native-select";
 import type { TeamH2HSummary } from "@/lib/team-details";
 
 type RivalOption = { id: string; name: string; type: "solo" | "duo" };
+
+function formatTeamTypeLabel(type: "solo" | "duo") {
+  return type === "solo" ? "Solo" : "Duplas";
+}
 
 export function H2HSection({
   rivals,
@@ -19,6 +27,10 @@ export function H2HSection({
   const [selectedId, setSelectedId] = useState(initial);
 
   const summary = useMemo(() => h2hByRival[selectedId], [h2hByRival, selectedId]);
+  const selectedRival = useMemo(
+    () => rivals.find((rival) => rival.id === selectedId) ?? null,
+    [rivals, selectedId],
+  );
 
   if (rivals.length === 0) {
     return <p className="text-sm text-muted-foreground">Nenhuma partida entre estes times</p>;
@@ -26,26 +38,61 @@ export function H2HSection({
 
   return (
     <div className="space-y-4">
-      <select
-        className="w-full rounded-md border border-border bg-surface px-3 py-2 text-sm"
-        value={selectedId}
-        onChange={(event) => setSelectedId(event.target.value)}
-      >
-        {rivals.map((rival) => (
-          <option key={rival.id} value={rival.id}>
-            {rival.name} ({rival.type === "solo" ? "Solo" : "Duplas"})
-          </option>
-        ))}
-      </select>
+      <div className="space-y-2">
+        <Label htmlFor="team-h2h-rival" className="caption text-muted-foreground">
+          Selecione o adversário
+        </Label>
+        <NativeSelect
+          id="team-h2h-rival"
+          value={selectedId}
+          onChange={(event) => setSelectedId(event.target.value)}
+        >
+          {rivals.map((rival) => (
+            <option key={rival.id} value={rival.id}>
+              {rival.name} ({formatTeamTypeLabel(rival.type)})
+            </option>
+          ))}
+        </NativeSelect>
+      </div>
 
       {!summary || summary.totalMatches === 0 ? (
         <p className="text-sm text-muted-foreground">Nenhuma partida entre estes times</p>
       ) : (
-        <div className="grid gap-2 rounded-lg border border-border bg-surface p-4 text-sm">
-          <p>Vitórias Contra: {summary.teamAWins}</p>
-          <p>Derrotas Para: {summary.teamBWins}</p>
-          <p>Taxa vs Adversário: {summary.winRate.toFixed(1)}%</p>
-          <p>Última Partida: {summary.lastMatchDate ? new Date(summary.lastMatchDate).toLocaleString("pt-BR") : "-"}</p>
+        <div className="space-y-4 rounded-lg border border-border bg-surface-emphasis p-4 shadow-sm shadow-foreground/5">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="font-semibold">{summary.rivalTeamName}</p>
+              {selectedRival ? (
+                <Badge variant="outline">{formatTeamTypeLabel(selectedRival.type)}</Badge>
+              ) : null}
+            </div>
+            <Badge variant="default">
+              {summary.totalMatches} {summary.totalMatches === 1 ? "partida" : "partidas"}
+            </Badge>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <StatTile
+              label="Vitórias"
+              value={summary.teamAWins}
+              className="border-border-strong bg-surface"
+            />
+            <StatTile
+              label="Derrotas"
+              value={summary.teamBWins}
+              className="border-border-strong bg-surface"
+            />
+            <StatTile
+              label="Aproveitamento"
+              value={`${summary.winRate.toFixed(1)}%`}
+              className="border-border-strong bg-surface"
+            />
+            <StatTile
+              label="Última partida"
+              value={summary.lastMatchDate ? new Date(summary.lastMatchDate).toLocaleDateString("pt-BR") : "-"}
+              className="border-border-strong bg-surface"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/teams/invite-member-dialog.tsx
+++ b/src/components/teams/invite-member-dialog.tsx
@@ -95,7 +95,7 @@ export function InviteMemberDialog({ teamId }: InviteMemberDialogProps) {
 
   return (
     <>
-      <Button type="button" onClick={() => setOpen(true)}>
+      <Button type="button" className="w-full sm:w-auto" onClick={() => setOpen(true)}>
         Convidar Membro
       </Button>
 

--- a/src/components/teams/member-list.tsx
+++ b/src/components/teams/member-list.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { TeamMemberView } from "@/lib/team-details";
@@ -15,6 +16,15 @@ type MemberListProps = {
   createdBy: string;
   viewerId: string;
 };
+
+function getInitials(name: string) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? "")
+    .join("");
+}
 
 function mapErrorStatus(status: number, fallbackMessage: string): string {
   if (status === 401) return "Faça login novamente para gerenciar membros.";
@@ -70,25 +80,38 @@ export function MemberList({ members, teamId, teamType, createdBy, viewerId }: M
         const isConfirming = confirmingUserId === member.userId;
         const isRemoving = removingUserId === member.userId;
         const removable = isRemovable(member);
+        const isViewer = member.userId === viewerId;
 
         return (
           <li
             key={member.userId}
-            className="flex items-center justify-between rounded-lg border border-border bg-surface p-3"
+            className="flex flex-col gap-3 rounded-lg border border-border bg-surface-emphasis p-4 shadow-sm shadow-foreground/5 sm:flex-row sm:items-center sm:justify-between"
           >
-            <div>
-              <p className="font-medium">{member.displayName}</p>
-              <p className="text-sm text-muted-foreground">@{member.username}</p>
+            <div className="flex items-center gap-3">
+              <Avatar className="size-10 border-0 bg-surface">
+                <AvatarFallback className="bg-surface">
+                  {getInitials(member.displayName)}
+                </AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-semibold">{member.displayName}</p>
+                  {isViewer ? <Badge variant="default">Você</Badge> : null}
+                  <Badge variant={member.role === "Criador" ? "gold" : "outline"}>
+                    {member.role}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">@{member.username}</p>
+              </div>
             </div>
 
-            <div className="flex items-center gap-2">
-              <Badge variant="outline">{member.role}</Badge>
-
+            <div className="flex flex-wrap items-center gap-2 sm:justify-end">
               {removable && !isConfirming && (
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
+                  className="w-full sm:w-auto"
                   onClick={() => setConfirmingUserId(member.userId)}
                   disabled={isRemoving}
                 >
@@ -102,7 +125,7 @@ export function MemberList({ members, teamId, teamType, createdBy, viewerId }: M
                     type="button"
                     variant="ghost"
                     size="sm"
-                    className="border-destructive text-destructive hover:bg-destructive/10"
+                    className="w-full border-destructive text-destructive hover:bg-destructive/10 sm:w-auto"
                     onClick={() => handleRemove(member.userId)}
                     disabled={isRemoving}
                   >
@@ -112,6 +135,7 @@ export function MemberList({ members, teamId, teamType, createdBy, viewerId }: M
                     type="button"
                     variant="ghost"
                     size="sm"
+                    className="w-full sm:w-auto"
                     onClick={() => setConfirmingUserId(null)}
                     disabled={isRemoving}
                   >

--- a/src/components/teams/recent-matches-list.tsx
+++ b/src/components/teams/recent-matches-list.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import type { MatchRecord } from "@/lib/types";
 
 function formatDate(value: string) {
@@ -31,16 +32,32 @@ export function RecentMatchesList({
           const won = match.winnerTeamId === teamId;
 
           return (
-            <li key={match.id} className="rounded-lg border border-border bg-surface p-3">
-              <p className="text-sm font-medium">
-                {won ? "Vitória" : "Derrota"} vs {opponentName}
-              </p>
-              <p className="text-xs text-muted-foreground">{formatDate(match.playedAt)}</p>
+            <li
+              key={match.id}
+              className="rounded-lg border border-border bg-surface-emphasis p-4 shadow-sm shadow-foreground/5"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:justify-between">
+                <div className="space-y-2">
+                  <Badge variant={won ? "default" : "outline"}>
+                    {won ? "Vitória" : "Derrota"}
+                  </Badge>
+                  <div>
+                    <p className="font-semibold">Contra {opponentName}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {won
+                        ? "Resultado positivo no confronto mais recente."
+                        : "Esse foi o revés mais recente contra esse adversário."}
+                    </p>
+                  </div>
+                </div>
+
+                <p className="caption text-muted-foreground sm:text-right">{formatDate(match.playedAt)}</p>
+              </div>
             </li>
           );
         })}
       </ul>
-      <p className="text-sm text-muted-foreground">Ver histórico completo</p>
+      <p className="caption text-muted-foreground">Mostrando as 3 partidas mais recentes.</p>
     </div>
   );
 }

--- a/src/components/teams/team-card.tsx
+++ b/src/components/teams/team-card.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
 import type { TeamRecord } from "@/lib/types";
 
@@ -19,9 +20,11 @@ export function TeamCard({ team }: { team: TeamRecord }) {
     <Link href={`/times/${team.id}`} className="block">
       <Card className="cursor-pointer shadow-sm shadow-foreground/10 transition hover:shadow-md hover:shadow-foreground/20">
         <div className="flex items-center gap-3 p-4">
-          <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-surface-emphasis text-xs font-semibold">
-            {getInitials(team.name)}
-          </div>
+          <Avatar className="size-9 border-0 bg-surface-emphasis">
+            <AvatarFallback className="bg-surface-emphasis text-xs">
+              {getInitials(team.name)}
+            </AvatarFallback>
+          </Avatar>
           <div className="min-w-0 flex-1 space-y-1.5">
             <p className="truncate text-sm font-semibold leading-none">{team.name}</p>
             <Badge variant="outline" className="text-xs">

--- a/src/components/teams/team-create-form.tsx
+++ b/src/components/teams/team-create-form.tsx
@@ -5,9 +5,12 @@ import { z } from "zod";
 import { toast } from "sonner";
 import { useRouter } from "next/navigation";
 
+import { Field, FieldError } from "@/components/primitives/form-field";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 import type { ApiErrorResponse, TeamRecord, TeamResponse } from "@/lib/types";
 
 const schema = z.object({
@@ -71,10 +74,8 @@ export function TeamCreateForm() {
   return (
     <Card className="max-w-md p-6">
       <form onSubmit={handleSubmit} className="space-y-5">
-        <div className="space-y-2">
-          <label htmlFor="team-name" className="text-sm font-medium text-foreground">
-            Nome do Time
-          </label>
+        <Field>
+          <Label htmlFor="team-name">Nome do Time</Label>
           <Input
             id="team-name"
             name="name"
@@ -89,32 +90,26 @@ export function TeamCreateForm() {
             invalid={!!nameError}
             aria-describedby={nameError ? "team-name-error" : undefined}
           />
-          {nameError && (
-            <p id="team-name-error" className="text-sm text-danger">
-              {nameError}
-            </p>
-          )}
-        </div>
+          <FieldError id="team-name-error">{nameError}</FieldError>
+        </Field>
 
-        <div className="space-y-2">
-          <p className="text-sm font-medium text-foreground">Modalidade</p>
-          <div className="flex gap-2">
+        <Field>
+          <Label>Modalidade</Label>
+          <SegmentedControl aria-label="Seleção de modalidade" className="w-full">
             {(["solo", "duo"] as const).map((option) => (
-              <button
+              <SegmentedControlItem
                 key={option}
                 type="button"
                 onClick={() => setType(option)}
-                className={`rounded-pill border px-4 py-2 text-sm transition-colors ${
-                  type === option
-                    ? "border-primary bg-primary text-foreground-inverse"
-                    : "border-border bg-surface text-muted-foreground hover:border-border-strong hover:bg-surface-emphasis hover:text-foreground"
-                }`}
+                active={type === option}
+                className="flex-1"
+                aria-pressed={type === option}
               >
                 {option === "solo" ? "Solo" : "Duplas"}
-              </button>
+              </SegmentedControlItem>
             ))}
-          </div>
-        </div>
+          </SegmentedControl>
+        </Field>
 
         <Button
           type="submit"

--- a/src/components/teams/team-detail-view.tsx
+++ b/src/components/teams/team-detail-view.tsx
@@ -2,59 +2,103 @@ import { H2HSection } from "@/components/teams/h2h-section";
 import { InviteMemberDialog } from "@/components/teams/invite-member-dialog";
 import { MemberList } from "@/components/teams/member-list";
 import { RecentMatchesList } from "@/components/teams/recent-matches-list";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { SectionHeader } from "@/components/primitives/section-header";
 import { StatTile } from "@/components/primitives/stat-tile";
 import type { TeamDetailData } from "@/lib/team-details";
+
+function formatTeamTypeLabel(type: "solo" | "duo") {
+  return type === "solo" ? "Solo" : "Duplas";
+}
+
+function formatCurrentStreakLabel(
+  streak: TeamDetailData["stats"]["currentStreak"],
+) {
+  if (streak.type === "none" || streak.count === 0) {
+    return "-";
+  }
+
+  return `${streak.count}${streak.type === "win" ? "V" : "D"}`;
+}
 
 export function TeamDetailView(data: TeamDetailData & { viewerId: string }) {
   const teamNameById = Object.fromEntries([
     [data.team.id, data.team.name],
     ...data.rivals.map((rival) => [rival.id, rival.name]),
   ]);
+  const teamTypeLabel = formatTeamTypeLabel(data.team.type);
+  const summaryText = `${data.stats.wins} vitórias, ${data.stats.losses} derrotas e ${data.stats.winRate.toFixed(1)}% de aproveitamento.`;
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-      <Card className="border-border-strong bg-surface-emphasis">
-        <CardHeader className="flex flex-row items-center justify-between gap-3">
-          <div>
-            <CardTitle className="title">{data.team.name}</CardTitle>
-            <p className="text-sm text-muted-foreground">{data.team.type === "solo" ? "Solo" : "Duplas"}</p>
+      <Card className="border-border-strong bg-surface-emphasis shadow-sm shadow-foreground/10">
+        <CardHeader className="gap-5 p-5 sm:p-6 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <p className="label-wide text-muted-foreground">Área de times</p>
+              <CardTitle className="title">{data.team.name}</CardTitle>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge variant="outline">{teamTypeLabel}</Badge>
+              <Badge variant="default">
+                {data.members.length} {data.members.length === 1 ? "membro" : "membros"}
+              </Badge>
+              {data.rankingPosition ? (
+                <Badge variant="gold">#{data.rankingPosition} no ranking</Badge>
+              ) : null}
+            </div>
+
+            <p className="max-w-2xl text-sm leading-6 text-muted-foreground">
+              {summaryText}
+            </p>
           </div>
-          <InviteMemberDialog teamId={data.team.id} />
+
+          <div className="w-full sm:w-auto sm:pt-1">
+            <InviteMemberDialog teamId={data.team.id} />
+          </div>
         </CardHeader>
       </Card>
 
       {/* per D-07 */}
       <section className="mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-        <StatTile label="Total Wins" value={data.stats.wins} />
-        <StatTile label="Total Losses" value={data.stats.losses} />
-        <StatTile label="Total de Partidas" value={data.stats.totalMatches} />
-        <StatTile label="Win Rate %" value={`${data.stats.winRate.toFixed(1)}%`} />
+        <StatTile label="Vitórias" value={data.stats.wins} />
+        <StatTile label="Derrotas" value={data.stats.losses} />
+        <StatTile label="Partidas jogadas" value={data.stats.totalMatches} />
+        <StatTile label="Aproveitamento" value={`${data.stats.winRate.toFixed(1)}%`} />
         <StatTile label="Posição no ranking" value={data.rankingPosition ?? "-"} />
         <StatTile
           label="Sequência Atual"
-          value={`${data.stats.currentStreak.count} ${data.stats.currentStreak.type === "win" ? "W" : data.stats.currentStreak.type === "loss" ? "L" : "-"}`}
+          value={formatCurrentStreakLabel(data.stats.currentStreak)}
         />
       </section>
 
       <section className="mt-6 grid gap-6 lg:grid-cols-2">
         <Card className="border-border bg-surface">
           <CardContent className="space-y-4 p-6">
-            <SectionHeader eyebrow="Time" title="Membros" />
+            <SectionHeader
+              eyebrow="Time"
+              title="Membros"
+              description="Quem faz parte do time e quem pode ser gerenciado nesta equipe."
+            />
             <MemberList
-                members={data.members}
-                teamId={data.team.id}
-                teamType={data.team.type}
-                createdBy={data.team.createdBy}
-                viewerId={data.viewerId}
-              />
+              members={data.members}
+              teamId={data.team.id}
+              teamType={data.team.type}
+              createdBy={data.team.createdBy}
+              viewerId={data.viewerId}
+            />
           </CardContent>
         </Card>
 
         <Card className="border-border bg-surface">
           <CardContent className="space-y-4 p-6">
-            <SectionHeader eyebrow="Partidas" title="Últimas Partidas" />
+            <SectionHeader
+              eyebrow="Partidas"
+              title="Últimas Partidas"
+              description="Resumo rápido dos confrontos mais recentes desse time."
+            />
             <RecentMatchesList
               matches={data.recentMatches}
               teamId={data.team.id}
@@ -68,7 +112,11 @@ export function TeamDetailView(data: TeamDetailData & { viewerId: string }) {
       <section className="mt-6">
         <Card className="border-border bg-surface">
           <CardContent className="space-y-4 p-6">
-            <SectionHeader eyebrow="Comparação" title="Confrontos Diretos" />
+            <SectionHeader
+              eyebrow="Comparação"
+              title="Confrontos Diretos"
+              description="Compare o desempenho do time contra cada adversário disponível."
+            />
             {/* addresses review concern: server-side H2H summary */}
             <H2HSection
               rivals={data.rivals}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function Avatar({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="avatar"
+      className={cn(
+        "relative flex shrink-0 overflow-hidden rounded-full border border-border bg-surface-emphasis",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function AvatarImage({ className, alt = "", ...props }: React.ImgHTMLAttributes<HTMLImageElement>) {
+  return (
+    <img
+      data-slot="avatar-image"
+      alt={alt}
+      className={cn("aspect-square size-full object-cover", className)}
+      {...props}
+    />
+  );
+}
+
+export function AvatarFallback({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center bg-surface-emphasis text-sm font-semibold uppercase text-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/native-select.tsx
+++ b/src/components/ui/native-select.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type NativeSelectProps = React.SelectHTMLAttributes<HTMLSelectElement> & {
+  invalid?: boolean;
+};
+
+const NativeSelect = React.forwardRef<HTMLSelectElement, NativeSelectProps>(
+  ({ className, invalid = false, "aria-invalid": ariaInvalid, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        aria-invalid={invalid || ariaInvalid ? true : undefined}
+        className={cn(
+          "h-13 w-full rounded-md border bg-surface-emphasis px-4 text-sm text-foreground outline-none transition disabled:cursor-not-allowed disabled:bg-surface-muted",
+          invalid
+            ? "border-danger focus:border-danger focus:ring-2 focus:ring-team-beta-soft"
+            : "border-border focus:border-primary focus:ring-2 focus:ring-team-alpha-soft",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+NativeSelect.displayName = "NativeSelect";
+
+export { NativeSelect };

--- a/src/components/ui/segmented-control.tsx
+++ b/src/components/ui/segmented-control.tsx
@@ -1,0 +1,57 @@
+import * as React from "react";
+
+import { Slot } from "@radix-ui/react-slot";
+import { cva } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const segmentedControlItemVariants = cva(
+  "inline-flex min-h-11 items-center justify-center rounded-md px-4 py-2 text-sm font-semibold text-muted-foreground transition-interactive outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      active: {
+        true: "bg-primary text-primary-foreground shadow-sm",
+        false: "hover:bg-surface hover:text-foreground",
+      },
+    },
+    defaultVariants: {
+      active: false,
+    },
+  },
+);
+
+type SegmentedControlProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function SegmentedControl({ className, ...props }: SegmentedControlProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex flex-wrap gap-2 rounded-lg border border-border bg-surface-emphasis p-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type SegmentedControlItemProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean;
+  asChild?: boolean;
+};
+
+export function SegmentedControlItem({
+  className,
+  active = false,
+  asChild = false,
+  ...props
+}: SegmentedControlItemProps) {
+  const Comp = asChild ? Slot : "button";
+
+  return (
+    <Comp
+      className={cn(segmentedControlItemVariants({ active }), className)}
+      data-active={active}
+      {...props}
+    />
+  );
+}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  invalid?: boolean;
+};
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, invalid = false, "aria-invalid": ariaInvalid, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        aria-invalid={invalid || ariaInvalid ? true : undefined}
+        className={cn(
+          "min-h-24 w-full rounded-md border bg-surface-emphasis px-4 py-3 text-sm text-foreground outline-none transition placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:bg-surface-muted",
+          invalid
+            ? "border-danger focus:border-danger focus:ring-2 focus:ring-team-beta-soft"
+            : "border-border focus:border-primary focus:ring-2 focus:ring-team-alpha-soft",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };


### PR DESCRIPTION
## Summary

This PR introduces a small set of shared UI primitives and applies them across key authenticated surfaces to make controls and visual patterns more consistent.

## Changes

- add shared `Avatar`, `SegmentedControl`, `NativeSelect`, and `Textarea` UI components
- replace ad-hoc tabs/selects/textareas in teams, ranking, login, dashboard, profile, and head-to-head screens
- refresh team detail/member/recent match presentation with clearer status, labels, and badges
- align the authenticated shell and team/profile cards with the new avatar treatment

## Verification

- `npm run typecheck`
- `npm run test -- src/components/login/login-screen.test.tsx src/components/teams/team-create-form.test.tsx src/components/teams/member-list.test.tsx src/components/teams/invite-member-dialog.test.tsx src/components/profile/profile-page.test.tsx src/components/profile/profile-edit-dialog.test.tsx src/components/ranking/ranking-view.test.tsx`
