### PR TITLE
fix(ui): replace native head-to-head selects

### DIFF
--- a/src/components/head-to-head/head-to-head-view.tsx
+++ b/src/components/head-to-head/head-to-head-view.tsx
@@ -3,7 +3,7 @@
 import { useRouter } from "next/navigation";
 
 import { Label } from "@/components/ui/label";
-import { NativeSelect } from "@/components/ui/native-select";
+import { Select } from "@/components/ui/select";
 import type { HeadToHeadPageData } from "@/lib/head-to-head";
 import type { TeamRecord } from "@/lib/types";
 
@@ -30,15 +30,15 @@ export function HeadToHeadView({ data }: Props) {
     return `/head-to-head?${params.toString()}`;
   }
 
-  function handleTeamAChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    const newTeamAId = event.target.value || null;
+  function handleTeamAChange(newValue: string) {
+    const newTeamAId = newValue || null;
     // D-17: prevent selecting same team on both sides
     const teamBId = pair.teamB?.id === newTeamAId ? null : pair.teamB?.id ?? null;
     router.push(buildUrl(newTeamAId, teamBId));
   }
 
-  function handleTeamBChange(event: React.ChangeEvent<HTMLSelectElement>) {
-    const newTeamBId = event.target.value || null;
+  function handleTeamBChange(newValue: string) {
+    const newTeamBId = newValue || null;
     // D-17: prevent selecting same team on both sides
     const teamAId = pair.teamA?.id === newTeamBId ? null : pair.teamA?.id ?? null;
     router.push(buildUrl(teamAId, newTeamBId));
@@ -74,20 +74,22 @@ export function HeadToHeadView({ data }: Props) {
             <Label htmlFor="selector-team-a">
               Team A
             </Label>
-            <NativeSelect
+            <Select
               id="selector-team-a"
               value={teamAId}
-              onChange={handleTeamAChange}
-            >
-              <option value="">Selecione um time...</option>
-              {options
-                .filter((team: TeamRecord) => team.id !== teamBId)
-                .map((team: TeamRecord) => (
-                  <option key={team.id} value={team.id}>
-                    {team.name} ({team.type === "solo" ? "Solo" : "Duplas"})
-                  </option>
-                ))}
-            </NativeSelect>
+              onValueChange={handleTeamAChange}
+              placeholder="Selecione um time..."
+              options={[
+                { value: "", label: "Selecione um time..." },
+                ...options
+                  .filter((team: TeamRecord) => team.id !== teamBId)
+                  .map((team: TeamRecord) => ({
+                    value: team.id,
+                    label: team.name,
+                    description: team.type === "solo" ? "Solo" : "Duplas",
+                  })),
+              ]}
+            />
           </div>
 
           {/* Team B selector */}
@@ -95,20 +97,22 @@ export function HeadToHeadView({ data }: Props) {
             <Label htmlFor="selector-team-b">
               Team B
             </Label>
-            <NativeSelect
+            <Select
               id="selector-team-b"
               value={teamBId}
-              onChange={handleTeamBChange}
-            >
-              <option value="">Selecione um time...</option>
-              {options
-                .filter((team: TeamRecord) => team.id !== teamAId)
-                .map((team: TeamRecord) => (
-                  <option key={team.id} value={team.id}>
-                    {team.name} ({team.type === "solo" ? "Solo" : "Duplas"})
-                  </option>
-                ))}
-            </NativeSelect>
+              onValueChange={handleTeamBChange}
+              placeholder="Selecione um time..."
+              options={[
+                { value: "", label: "Selecione um time..." },
+                ...options
+                  .filter((team: TeamRecord) => team.id !== teamAId)
+                  .map((team: TeamRecord) => ({
+                    value: team.id,
+                    label: team.name,
+                    description: team.type === "solo" ? "Solo" : "Duplas",
+                  })),
+              ]}
+            />
           </div>
         </div>
 

--- a/src/components/teams/h2h-section.tsx
+++ b/src/components/teams/h2h-section.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from "react";
 import { StatTile } from "@/components/primitives/stat-tile";
 import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
-import { NativeSelect } from "@/components/ui/native-select";
+import { Select } from "@/components/ui/select";
 import type { TeamH2HSummary } from "@/lib/team-details";
 
 type RivalOption = { id: string; name: string; type: "solo" | "duo" };
@@ -42,17 +42,16 @@ export function H2HSection({
         <Label htmlFor="team-h2h-rival" className="caption text-muted-foreground">
           Selecione o adversário
         </Label>
-        <NativeSelect
+        <Select
           id="team-h2h-rival"
           value={selectedId}
-          onChange={(event) => setSelectedId(event.target.value)}
-        >
-          {rivals.map((rival) => (
-            <option key={rival.id} value={rival.id}>
-              {rival.name} ({formatTeamTypeLabel(rival.type)})
-            </option>
-          ))}
-        </NativeSelect>
+          onValueChange={setSelectedId}
+          options={rivals.map((rival) => ({
+            value: rival.id,
+            label: rival.name,
+            description: formatTeamTypeLabel(rival.type),
+          }))}
+        />
       </div>
 
       {!summary || summary.totalMatches === 0 ? (

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import * as React from "react";
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CheckIcon, ChevronDownIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export type SelectOption = {
+  value: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+};
+
+export type SelectProps = {
+  id?: string;
+  name?: string;
+  value?: string;
+  defaultValue?: string;
+  placeholder?: string;
+  disabled?: boolean;
+  invalid?: boolean;
+  className?: string;
+  popupClassName?: string;
+  options: SelectOption[];
+  onValueChange?: (value: string) => void;
+};
+
+const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
+  (
+    {
+      id,
+      name,
+      value,
+      defaultValue,
+      placeholder = "Selecione uma opção",
+      disabled = false,
+      invalid = false,
+      className,
+      popupClassName,
+      options,
+      onValueChange,
+    },
+    ref,
+  ) => {
+    const optionsByValue = React.useMemo(
+      () =>
+        new Map(
+          options.map((option) => [
+            option.value,
+            { label: option.label, description: option.description },
+          ]),
+        ),
+      [options],
+    );
+
+    const controlledProps =
+      value !== undefined
+        ? { value }
+        : defaultValue !== undefined
+          ? { defaultValue }
+          : {};
+
+    return (
+      <SelectPrimitive.Root
+        name={name}
+        disabled={disabled}
+        onValueChange={(nextValue) => {
+          if (typeof nextValue === "string") {
+            onValueChange?.(nextValue);
+          }
+        }}
+        {...controlledProps}
+      >
+        <SelectPrimitive.Trigger
+          ref={ref}
+          id={id}
+          aria-invalid={invalid ? true : undefined}
+          className={cn(
+            "group flex h-13 w-full items-center gap-3 rounded-xl border bg-surface-emphasis px-4 text-left text-foreground shadow-sm shadow-foreground/5 outline-none transition-interactive hover:border-border-strong hover:bg-surface data-[popup-open]:border-primary data-[popup-open]:bg-surface data-[popup-open]:shadow-md data-[popup-open]:shadow-foreground/10 data-[disabled]:cursor-not-allowed data-[disabled]:bg-surface-muted data-[disabled]:opacity-60 focus-visible:ring-2",
+            invalid
+              ? "border-danger focus-visible:ring-team-beta-soft"
+              : "border-border focus-visible:ring-team-alpha-soft",
+            className,
+          )}
+        >
+          <SelectPrimitive.Value placeholder={placeholder}>
+            {(selectedValue: string | null) => {
+              const selectedOption = selectedValue ? optionsByValue.get(selectedValue) : null;
+
+              if (!selectedOption) {
+                return <span className="truncate text-sm text-muted-foreground">{placeholder}</span>;
+              }
+
+              return (
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {selectedOption.label}
+                  </span>
+                  {selectedOption.description ? (
+                    <span className="truncate text-xs text-muted-foreground">
+                      {selectedOption.description}
+                    </span>
+                  ) : null}
+                </span>
+              );
+            }}
+          </SelectPrimitive.Value>
+          <SelectPrimitive.Icon className="ml-auto shrink-0 text-muted-foreground transition-transform duration-200 group-data-[popup-open]:rotate-180">
+            <ChevronDownIcon className="size-4" />
+          </SelectPrimitive.Icon>
+        </SelectPrimitive.Trigger>
+
+        <SelectPrimitive.Portal>
+          <SelectPrimitive.Positioner sideOffset={8}>
+            <SelectPrimitive.Popup
+              className={cn(
+                "z-50 overflow-hidden rounded-2xl border border-border bg-background shadow-lg shadow-foreground/10 backdrop-blur-sm transition-all duration-150 ease-out data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",
+                popupClassName,
+              )}
+              style={{ width: "var(--anchor-width)" }}
+            >
+              <SelectPrimitive.List className="max-h-72 overflow-y-auto p-1.5">
+                {options.map((option) => (
+                  <SelectPrimitive.Item
+                    key={option.value}
+                    value={option.value}
+                    label={option.label}
+                    disabled={option.disabled}
+                    className="flex cursor-default items-center gap-3 rounded-xl px-3 py-2.5 text-foreground outline-none transition-colors data-[highlighted]:bg-surface-emphasis data-[selected]:bg-surface data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <SelectPrimitive.ItemText className="block truncate text-sm font-medium">
+                        {option.label}
+                      </SelectPrimitive.ItemText>
+                      {option.description ? (
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {option.description}
+                        </span>
+                      ) : null}
+                    </div>
+                    <SelectPrimitive.ItemIndicator className="text-team-alpha">
+                      <CheckIcon className="size-4" />
+                    </SelectPrimitive.ItemIndicator>
+                  </SelectPrimitive.Item>
+                ))}
+              </SelectPrimitive.List>
+            </SelectPrimitive.Popup>
+          </SelectPrimitive.Positioner>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
+    );
+  },
+);
+Select.displayName = "Select";
+
+export { Select };


### PR DESCRIPTION
## Summary

Replace the native browser select styling used in the head-to-head flows with a custom Tailwind/Base UI select component that matches the app design system more closely.

## Changes

- add a reusable custom `Select` component for styled single-select fields
- migrate the team detail head-to-head rival selector to the new component
- migrate both `/head-to-head` team selectors to the new component
- preserve the existing URL-sync and "clear conflicting team" behavior

## Verification

- [x] `npm run typecheck`

## Notes

- no active GSD phase was detected for this work, so this PR is scoped as a targeted UI fix rather than a phase PR
- unrelated local changes in `.planning/` and other files were intentionally left out of this commit
