### PR TITLE
fix(ranking): compact header filters

### DIFF
--- a/src/components/ranking/period-tabs.tsx
+++ b/src/components/ranking/period-tabs.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
-import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 
 type RankingPeriod = "all" | "month" | "week";
 
-const TABS: Array<{ label: string; value: RankingPeriod }> = [
-  { label: "Todos os tempos", value: "all" },
-  { label: "Este mês", value: "month" },
-  { label: "Esta semana", value: "week" },
+const TABS: Array<{ label: string; value: RankingPeriod; description: string }> = [
+  { label: "Todos os tempos", value: "all", description: "Histórico completo" },
+  { label: "Este mês", value: "month", description: "Últimos 30 dias" },
+  { label: "Esta semana", value: "week", description: "Últimos 7 dias" },
 ];
 
 export function PeriodTabs({
@@ -19,6 +20,8 @@ export function PeriodTabs({
   activePeriod: RankingPeriod;
   activeType: "all" | "solo" | "duo";
 }) {
+  const router = useRouter();
+
   function buildHref(period: RankingPeriod): string {
     const params = new URLSearchParams();
     if (activeType !== "all") params.set("type", activeType);
@@ -28,21 +31,22 @@ export function PeriodTabs({
   }
 
   return (
-    <SegmentedControl aria-label="Filtro de período" role="navigation">
-      {TABS.map((tab) => {
-        const active = tab.value === activePeriod;
-        return (
-          <SegmentedControlItem
-            key={tab.value}
-            asChild
-            active={active}
-          >
-            <Link href={buildHref(tab.value)} aria-current={active ? "page" : undefined}>
-              {tab.label}
-            </Link>
-          </SegmentedControlItem>
-        );
-      })}
-    </SegmentedControl>
+    <div className="space-y-1 xl:space-y-0">
+      <Label htmlFor="ranking-period-filter" className="caption text-muted-foreground xl:sr-only">
+        Período
+      </Label>
+      <Select
+        id="ranking-period-filter"
+        value={activePeriod}
+        onValueChange={(nextValue) => {
+          if (nextValue !== activePeriod) {
+            router.push(buildHref(nextValue as RankingPeriod));
+          }
+        }}
+        className="h-10 rounded-lg px-3"
+        showDescriptionInTrigger={false}
+        options={TABS}
+      />
+    </div>
   );
 }

--- a/src/components/ranking/ranking-view.test.tsx
+++ b/src/components/ranking/ranking-view.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { RankingView } from "@/components/ranking/ranking-view";
@@ -6,6 +7,13 @@ import type { RankedTeam } from "@/lib/ranking";
 
 const mockListAllTeamsWithStats = vi.fn();
 const mockHasDatabaseUrl = vi.fn();
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
 
 vi.mock("@/lib/ranking", async () => {
   const actual = await vi.importActual<typeof import("@/lib/ranking")>("@/lib/ranking");
@@ -107,6 +115,10 @@ const teams: RankedTeam[] = [
 ];
 
 describe("RankingView", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+  });
+
   it("renders podium in 2 | 1 | 3 order", () => {
     render(<RankingView teams={teams} activeType="all" mode="available" />);
 
@@ -155,12 +167,8 @@ describe("RankingView", () => {
   it("renders unavailable header without ranking content", () => {
     render(<RankingView teams={[]} activeType="duo" mode="unavailable" />);
     expect(screen.getByRole("heading", { name: "Placar de times" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("navigation", { name: "Filtro de tipo de time" }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole("navigation", { name: "Filtro de período" }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Categoria")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Período")).not.toBeInTheDocument();
     expect(screen.queryByTestId("empty-state")).not.toBeInTheDocument();
   });
 
@@ -189,10 +197,8 @@ describe("RankingView", () => {
     render(
       <RankingView teams={[]} activeType="solo" activePeriod="month" mode="available" />,
     );
-    // Type tabs nav present
-    expect(screen.getByRole("navigation", { name: "Filtro de tipo de time" })).toBeInTheDocument();
-    // Period tabs nav present
-    expect(screen.getByRole("navigation", { name: "Filtro de período" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Categoria")).toBeInTheDocument();
+    expect(screen.getByLabelText("Período")).toBeInTheDocument();
   });
 
   it("empty state shows period-aware message without falling back to all-time", () => {
@@ -204,20 +210,26 @@ describe("RankingView", () => {
     expect(screen.queryByText(/nesta categoria/)).not.toBeInTheDocument();
   });
 
-  it("type tab links preserve active period in href", () => {
+  it("type filter preserves active period when changing the selection", async () => {
+    const user = userEvent.setup();
+
     render(<RankingView teams={teams} activeType="all" activePeriod="month" mode="available" />);
-    const links = screen.getAllByRole("link");
-    // The "Solo" tab should include period=month when switching to solo
-    const soloLink = links.find((l) => l.textContent === "Solo");
-    expect(soloLink?.getAttribute("href")).toBe("/ranking?type=solo&period=month");
+
+    await user.click(screen.getByRole("combobox", { name: "Categoria" }));
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(mockPush).toHaveBeenCalledWith("/ranking?type=solo&period=month");
   });
 
-  it("period tab links preserve active type in href", () => {
+  it("period filter preserves active type when changing the selection", async () => {
+    const user = userEvent.setup();
+
     render(<RankingView teams={teams} activeType="solo" activePeriod="all" mode="available" />);
-    const links = screen.getAllByRole("link");
-    // The "Esta semana" tab should include type=solo when switching to week
-    const weekLink = links.find((l) => l.textContent === "Esta semana");
-    expect(weekLink?.getAttribute("href")).toBe("/ranking?type=solo&period=week");
+
+    await user.click(screen.getByRole("combobox", { name: "Período" }));
+    await user.keyboard("{ArrowDown}{ArrowDown}{Enter}");
+
+    expect(mockPush).toHaveBeenCalledWith("/ranking?type=solo&period=week");
   });
 });
 

--- a/src/components/ranking/ranking-view.tsx
+++ b/src/components/ranking/ranking-view.tsx
@@ -21,6 +21,13 @@ export function RankingView({
   activePeriod?: "all" | "month" | "week";
   mode: "available" | "unavailable";
 }) {
+  const filters = (
+    <div className="grid gap-3 sm:grid-cols-2 xl:ml-auto xl:w-full xl:max-w-xl">
+      <TypeTabs activeType={activeType} activePeriod={activePeriod} />
+      <PeriodTabs activePeriod={activePeriod} activeType={activeType} />
+    </div>
+  );
+
   if (mode === "unavailable") {
     return (
       <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
@@ -35,14 +42,12 @@ export function RankingView({
   if (teams.length === 0) {
     return (
       <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-        <div className="mb-6">
-          <p className="label-wide text-muted-foreground">Ranking</p>
-          <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
-        </div>
-        {/* per D-02, D-12: both filter groups remain visible in empty state */}
-        <TypeTabs activeType={activeType} activePeriod={activePeriod} />
-        <div className="mt-4">
-          <PeriodTabs activePeriod={activePeriod} activeType={activeType} />
+        <div className="mb-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+          <div>
+            <p className="label-wide text-muted-foreground">Ranking</p>
+            <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
+          </div>
+          {filters}
         </div>
         {/* per D-13: explicit empty state without automatic fallback to all-time */}
         <div
@@ -68,14 +73,12 @@ export function RankingView({
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mb-6">
-        <p className="label-wide text-muted-foreground">Ranking</p>
-        <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
-      </div>
-      {/* per D-02, D-12: type and period filters coexist */}
-      <TypeTabs activeType={activeType} activePeriod={activePeriod} />
-      <div className="mt-4">
-        <PeriodTabs activePeriod={activePeriod} activeType={activeType} />
+      <div className="mb-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <p className="label-wide text-muted-foreground">Ranking</p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight">Placar de times</h1>
+        </div>
+        {filters}
       </div>
 
       <section aria-label="Pódio" className="mt-6 grid gap-4 lg:grid-cols-3">

--- a/src/components/ranking/type-tabs.tsx
+++ b/src/components/ranking/type-tabs.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 
-import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
 
 type RankingType = "all" | "solo" | "duo";
 
-const TYPE_VALUES: Array<{ label: string; value: RankingType }> = [
-  { label: "Todos", value: "all" },
-  { label: "Solo", value: "solo" },
-  { label: "Duplas", value: "duo" },
+const TYPE_VALUES: Array<{ label: string; value: RankingType; description: string }> = [
+  { label: "Todos", value: "all", description: "Todos os formatos" },
+  { label: "Solo", value: "solo", description: "Apenas times solo" },
+  { label: "Duplas", value: "duo", description: "Apenas duplas" },
 ];
 
 export function TypeTabs({
@@ -19,6 +20,8 @@ export function TypeTabs({
   activeType: RankingType;
   activePeriod?: "all" | "month" | "week";
 }) {
+  const router = useRouter();
+
   function buildHref(type: RankingType): string {
     const params = new URLSearchParams();
     if (type !== "all") params.set("type", type);
@@ -28,21 +31,22 @@ export function TypeTabs({
   }
 
   return (
-    <SegmentedControl aria-label="Filtro de tipo de time" role="navigation">
-      {TYPE_VALUES.map((tab) => {
-        const active = tab.value === activeType;
-        return (
-          <SegmentedControlItem
-            key={tab.value}
-            asChild
-            active={active}
-          >
-            <Link href={buildHref(tab.value)} aria-current={active ? "page" : undefined}>
-              {tab.label}
-            </Link>
-          </SegmentedControlItem>
-        );
-      })}
-    </SegmentedControl>
+    <div className="space-y-1 xl:space-y-0">
+      <Label htmlFor="ranking-type-filter" className="caption text-muted-foreground xl:sr-only">
+        Categoria
+      </Label>
+      <Select
+        id="ranking-type-filter"
+        value={activeType}
+        onValueChange={(nextValue) => {
+          if (nextValue !== activeType) {
+            router.push(buildHref(nextValue as RankingType));
+          }
+        }}
+        className="h-10 rounded-lg px-3"
+        showDescriptionInTrigger={false}
+        options={TYPE_VALUES}
+      />
+    </div>
   );
 }

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -23,6 +23,7 @@ export type SelectProps = {
   invalid?: boolean;
   className?: string;
   popupClassName?: string;
+  showDescriptionInTrigger?: boolean;
   options: SelectOption[];
   onValueChange?: (value: string) => void;
 };
@@ -39,6 +40,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
       invalid = false,
       className,
       popupClassName,
+      showDescriptionInTrigger = true,
       options,
       onValueChange,
     },
@@ -98,7 +100,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
                   <span className="truncate text-sm font-medium text-foreground">
                     {selectedOption.label}
                   </span>
-                  {selectedOption.description ? (
+                  {showDescriptionInTrigger && selectedOption.description ? (
                     <span className="truncate text-xs text-muted-foreground">
                       {selectedOption.description}
                     </span>
@@ -113,7 +115,7 @@ const Select = React.forwardRef<HTMLButtonElement, SelectProps>(
         </SelectPrimitive.Trigger>
 
         <SelectPrimitive.Portal>
-          <SelectPrimitive.Positioner sideOffset={8}>
+          <SelectPrimitive.Positioner alignItemWithTrigger={false} sideOffset={8}>
             <SelectPrimitive.Popup
               className={cn(
                 "z-50 overflow-hidden rounded-2xl border border-border bg-background shadow-lg shadow-foreground/10 backdrop-blur-sm transition-all duration-150 ease-out data-[starting-style]:scale-95 data-[starting-style]:opacity-0 data-[ending-style]:scale-95 data-[ending-style]:opacity-0",


### PR DESCRIPTION
## Summary

Refine the ranking header so it uses horizontal space better and feels closer to a toolbar than a stacked form block.

## What Changed

- move the ranking type and period filters into the same header row as `Ranking` / `Placar de times`
- replace the old segmented filter groups with compact select-based controls
- keep the current URL-driven filter behavior by navigating with `router.push`
- compact the ranking filter triggers so they align better with the left header content
- adjust the shared select popup positioning to avoid opening mid-list with an immediate scrollbar when the selected option is near the end

## Verification

- [x] `npx vitest run src/components/ranking/ranking-view.test.tsx`
- [x] `npm run typecheck`

## Notes

- this PR includes only the ranking/select refinements
- unrelated local changes already present in `.planning/` and other files were intentionally left out
