### PR TITLE
feat(times): align teams page with ranking layout

### DIFF
--- a/src/app/(authenticated)/times/page.tsx
+++ b/src/app/(authenticated)/times/page.tsx
@@ -1,21 +1,21 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { Users } from "lucide-react";
+import { ArrowLeft, Filter, Users } from "lucide-react";
 
+import { TeamPartnerFilter } from "@/components/teams/partner-filter";
 import { TeamCard } from "@/components/teams/team-card";
 import { TeamCreateForm } from "@/components/teams/team-create-form";
 import { IconCallout } from "@/components/primitives/icon-callout";
-import { SegmentedControl, SegmentedControlItem } from "@/components/ui/segmented-control";
 import { getAuthenticatedUser, hasDatabaseUrl } from "@/lib/auth";
-import { listUserTeams } from "@/lib/teams";
+import { listUserTeamsWithPartners } from "@/lib/teams";
 
 export const metadata: Metadata = {
   title: "Times | Office 8 Ball",
-  description: "Área de times com abas de listagem e criação.",
+  description: "Área de times com listagem, filtro por parceiro e criação de novos times.",
 };
 
 type TeamsPageProps = {
-  searchParams?: Promise<{ tab?: string }>;
+  searchParams?: Promise<{ partner?: string; tab?: string }>;
 };
 
 export default async function TeamsPage({ searchParams }: TeamsPageProps) {
@@ -25,41 +25,75 @@ export default async function TeamsPage({ searchParams }: TeamsPageProps) {
   const user = databaseReady ? await getAuthenticatedUser() : null;
   const teams =
     databaseReady && user
-      ? await listUserTeams(user.id)
+      ? await listUserTeamsWithPartners(user.id)
       : [];
+  const partnerTotals = new Map<string, { displayName: string; teamCount: number }>();
+
+  for (const team of teams) {
+    for (const partner of team.partners) {
+      const current = partnerTotals.get(partner.userId);
+      partnerTotals.set(partner.userId, {
+        displayName: partner.displayName,
+        teamCount: (current?.teamCount ?? 0) + 1,
+      });
+    }
+  }
+
+  const partners = Array.from(partnerTotals.entries())
+    .map(([userId, partner]) => ({
+      userId,
+      displayName: partner.displayName,
+      teamCount: partner.teamCount,
+    }))
+    .sort((left, right) => left.displayName.localeCompare(right.displayName, "pt-BR"));
+  const requestedPartnerId = resolved.partner;
+  const activePartnerId = requestedPartnerId && partners.some((partner) => partner.userId === requestedPartnerId)
+    ? requestedPartnerId
+    : "all";
+  const activePartner =
+    activePartnerId === "all"
+      ? null
+      : partners.find((partner) => partner.userId === activePartnerId) ?? null;
+  const filteredTeams =
+    activePartnerId === "all"
+      ? teams
+      : teams.filter((team) => team.partners.some((partner) => partner.userId === activePartnerId));
+  const title = tab === "create" ? "Criar novo time" : "Meus times";
 
   return (
     <main className="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mb-6">
-        <p className="label-wide text-muted-foreground">Área de times</p>
-        <h1 className="mt-1 text-xl font-semibold tracking-tight">
-          {tab === "create" ? "Criar novo time" : "Meus times"}
-          {tab === "teams" && teams.length > 0 && (
-            <span className="ml-2 text-sm font-normal text-muted-foreground">
-              {teams.length} {teams.length === 1 ? "time" : "times"}
-            </span>
-          )}
-        </h1>
+      <div className="mb-6 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+        <div>
+          <p className="label-wide text-muted-foreground">Times</p>
+          <h1 className="mt-1 text-xl font-semibold tracking-tight">{title}</h1>
+        </div>
+
+        {tab === "teams" ? (
+          <div className="w-full xl:ml-auto xl:max-w-sm">
+            <TeamPartnerFilter activePartnerId={activePartnerId} partners={partners} />
+          </div>
+        ) : null}
       </div>
 
-      <SegmentedControl aria-label="Navegação da área de times" role="navigation">
-        <SegmentedControlItem asChild active={tab === "teams"}>
-          <Link href="/times?tab=teams" aria-current={tab === "teams" ? "page" : undefined}>
-            Meus Times
-          </Link>
-        </SegmentedControlItem>
-        <SegmentedControlItem asChild active={tab === "create"}>
-          <Link href="/times?tab=create" aria-current={tab === "create" ? "page" : undefined}>
-            Criar Novo Time
-          </Link>
-        </SegmentedControlItem>
-      </SegmentedControl>
-
-      <div className={`mt-6 ${tab === "teams" ? "grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]" : ""}`}>
-        <section className="space-y-3">
-          {tab === "teams" ? (
-            teams.length > 0 ? (
-              teams.map((team) => <TeamCard key={team.id} team={team} />)
+      {tab === "teams" ? (
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,7fr)_minmax(280px,3fr)]">
+          <section className="space-y-3">
+            {filteredTeams.length > 0 ? (
+              filteredTeams.map((team) => <TeamCard key={team.id} team={team} />)
+            ) : teams.length > 0 && activePartner ? (
+              <div className="space-y-3 pt-1">
+                <IconCallout
+                  icon={<Filter className="size-4" />}
+                  title={`Nenhum time com ${activePartner.displayName}`}
+                  description="Troque o parceiro no filtro para voltar a visualizar outras formações."
+                />
+                <Link
+                  href="/times"
+                  className="inline-flex rounded-pill border border-border bg-surface px-4 py-2 text-sm text-foreground transition-colors hover:border-border-strong hover:bg-surface-emphasis"
+                >
+                  Limpar filtro
+                </Link>
+              </div>
             ) : (
               <div className="space-y-3 pt-1">
                 <IconCallout
@@ -74,27 +108,50 @@ export default async function TeamsPage({ searchParams }: TeamsPageProps) {
                   Criar primeiro time
                 </Link>
               </div>
-            )
-          ) : (
-            <TeamCreateForm />
-          )}
-        </section>
+            )}
+          </section>
 
-        {tab === "teams" && (
-          <aside className="hidden rounded-lg border border-border bg-surface p-5 lg:block">
-            <h2 className="text-sm font-semibold">Criar Novo Time</h2>
-            <p className="mt-2 text-sm text-muted-foreground">
-              Configure um time solo ou em dupla para registrar partidas.
-            </p>
-            <Link
-              href="/times?tab=create"
-              className="mt-4 inline-flex rounded-pill border border-primary bg-primary px-4 py-2 text-sm text-foreground-inverse transition-colors hover:opacity-90"
-            >
-              Criar Novo Time
-            </Link>
+          <aside className="space-y-4">
+            <div className="rounded-lg border border-border bg-surface p-5">
+              <h2 className="text-sm font-semibold">Criar Novo Time</h2>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Configure um time solo ou em dupla para registrar partidas e acompanhar a evolução no ranking.
+              </p>
+              <Link
+                href="/times?tab=create"
+                className="mt-4 inline-flex rounded-pill border border-primary bg-primary px-4 py-2 text-sm text-foreground-inverse transition-colors hover:opacity-90"
+              >
+                Criar Novo Time
+              </Link>
+            </div>
+
+            <div className="rounded-lg border border-border bg-surface-emphasis p-5">
+              <p className="caption text-muted-foreground">Visão atual</p>
+              <p className="mt-2 text-lg font-semibold tracking-tight">
+                {filteredTeams.length} {filteredTeams.length === 1 ? "time visível" : "times visíveis"}
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {activePartner
+                  ? `Filtro ativo para jogos em parceria com ${activePartner.displayName}.`
+                  : partners.length > 0
+                    ? `Você tem ${partners.length} ${partners.length === 1 ? "parceiro listado" : "parceiros listados"} para filtrar.`
+                    : "Assim que você criar duplas, seus parceiros vão aparecer aqui para filtrar a lista."}
+              </p>
+            </div>
           </aside>
-        )}
-      </div>
+        </div>
+      ) : (
+        <section className="max-w-3xl space-y-4">
+          <Link
+            href="/times"
+            className="inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            Voltar para meus times
+          </Link>
+          <TeamCreateForm />
+        </section>
+      )}
     </main>
   );
 }

--- a/src/components/teams/partner-filter.tsx
+++ b/src/components/teams/partner-filter.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+
+type TeamPartnerFilterProps = {
+  activePartnerId: string;
+  partners: Array<{
+    userId: string;
+    displayName: string;
+    teamCount: number;
+  }>;
+};
+
+export function TeamPartnerFilter({
+  activePartnerId,
+  partners,
+}: TeamPartnerFilterProps) {
+  const router = useRouter();
+  const hasPartners = partners.length > 0;
+  const options = [
+    {
+      label: "Todos os parceiros",
+      value: "all",
+      description: hasPartners
+        ? `${partners.length} ${partners.length === 1 ? "parceiro disponível" : "parceiros disponíveis"}`
+        : "Nenhuma dupla com parceiro ainda",
+    },
+    ...partners.map((partner) => ({
+      label: partner.displayName,
+      value: partner.userId,
+      description:
+        partner.teamCount === 1
+          ? "1 time com você"
+          : `${partner.teamCount} times com você`,
+    })),
+  ];
+
+  function buildHref(partnerId: string) {
+    if (partnerId === "all") {
+      return "/times";
+    }
+
+    const params = new URLSearchParams();
+    params.set("partner", partnerId);
+    return `/times?${params.toString()}`;
+  }
+
+  return (
+    <div className="space-y-1 xl:space-y-0">
+      <Label htmlFor="team-partner-filter" className="caption text-muted-foreground xl:sr-only">
+        Filtrar por parceiro
+      </Label>
+      <Select
+        id="team-partner-filter"
+        value={activePartnerId}
+        disabled={!hasPartners}
+        onValueChange={(nextValue) => {
+          if (nextValue !== activePartnerId) {
+            router.push(buildHref(nextValue));
+          }
+        }}
+        className="h-10 rounded-lg px-3"
+        showDescriptionInTrigger={false}
+        options={options}
+      />
+    </div>
+  );
+}

--- a/src/components/teams/team-card.test.tsx
+++ b/src/components/teams/team-card.test.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TeamCard } from "@/components/teams/team-card";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe("TeamCard", () => {
+  it("renders partner, summary stats and activity metadata for duo teams", () => {
+    render(
+      <TeamCard
+        team={{
+          id: "team-1",
+          name: "dupla afiada",
+          type: "duo",
+          status: "active",
+          createdBy: "user-1",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          members: [
+            { userId: "user-1", joinedAt: "2026-01-01T00:00:00.000Z" },
+            { userId: "user-2", joinedAt: "2026-01-02T00:00:00.000Z" },
+          ],
+          partners: [{ userId: "user-2", username: "jean.dev", displayName: "Jean" }],
+          summary: {
+            wins: 4,
+            losses: 2,
+            winRate: 66.7,
+            totalMatches: 6,
+            lastFiveResults: ["win", "loss", "win", "win", "loss"],
+            lastPlayedAt: "2026-01-12T00:00:00.000Z",
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/times/team-1");
+    expect(screen.getByText("Com Jean")).toBeInTheDocument();
+    expect(screen.getByText("4V · 2D")).toBeInTheDocument();
+    expect(screen.getByText("66.7%")).toBeInTheDocument();
+    expect(screen.getByText("6 partidas registradas")).toBeInTheDocument();
+    expect(screen.getByText(/Última partida em/i)).toBeInTheDocument();
+  });
+
+  it("renders a stable empty-state summary for solo teams without matches", () => {
+    render(
+      <TeamCard
+        team={{
+          id: "team-2",
+          name: "lobo solo",
+          type: "solo",
+          status: "active",
+          createdBy: "user-1",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          members: [{ userId: "user-1", joinedAt: "2026-01-01T00:00:00.000Z" }],
+          partners: [],
+          summary: {
+            wins: 0,
+            losses: 0,
+            winRate: 0,
+            totalMatches: 0,
+            lastFiveResults: [],
+            lastPlayedAt: null,
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Time solo")).toBeInTheDocument();
+    expect(screen.getByText("Nenhuma partida registrada")).toBeInTheDocument();
+    expect(screen.getByText("Aguardando primeira partida")).toBeInTheDocument();
+  });
+});

--- a/src/components/teams/team-card.tsx
+++ b/src/components/teams/team-card.tsx
@@ -4,7 +4,8 @@ import { ChevronRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
-import type { TeamRecord } from "@/lib/types";
+import type { UserTeamOverview } from "@/lib/teams";
+import { cn } from "@/lib/utils";
 
 function getInitials(name: string) {
   return name
@@ -15,26 +16,104 @@ function getInitials(name: string) {
     .join("");
 }
 
-export function TeamCard({ team }: { team: TeamRecord }) {
+function formatLastPlayedAt(value: string | null) {
+  if (!value) return "Sem partidas ainda";
+
+  return new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "short",
+  }).format(new Date(value));
+}
+
+function RecentResultsDots({
+  results,
+  teamName,
+}: {
+  results: UserTeamOverview["summary"]["lastFiveResults"];
+  teamName: string;
+}) {
+  const slots = [...results, ...Array.from({ length: Math.max(0, 5 - results.length) }, () => "none" as const)];
+
+  return (
+    <div className="flex items-center gap-1.5" aria-label={`Últimas 5 partidas de ${teamName}`}>
+      {slots.map((result, index) => (
+        <span
+          key={`${teamName}-${index}`}
+          aria-label={
+            result === "win"
+              ? `Partida ${index + 1}: vitória`
+              : result === "loss"
+                ? `Partida ${index + 1}: derrota`
+                : `Partida ${index + 1}: sem histórico`
+          }
+          className={cn(
+            "block h-2.5 w-2.5 rounded-full border",
+            result === "win" && "border-primary/70 bg-primary",
+            result === "loss" && "border-danger/70 bg-danger",
+            result === "none" && "border-border bg-surface-muted",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function TeamCard({ team }: { team: UserTeamOverview }) {
+  const partnerLabel =
+    team.partners.length === 0
+      ? "Time solo"
+      : team.partners.length === 1
+        ? `Com ${team.partners[0]?.displayName}`
+        : `Parceiros: ${team.partners.map((partner) => partner.displayName).join(", ")}`;
+
   return (
     <Link href={`/times/${team.id}`} className="block">
       <Card className="cursor-pointer shadow-sm shadow-foreground/10 transition hover:shadow-md hover:shadow-foreground/20">
-        <div className="flex items-center gap-3 p-4">
+        <div className="flex items-start gap-3 p-4">
           <Avatar className="size-9 border-0 bg-surface-emphasis">
             <AvatarFallback className="bg-surface-emphasis text-xs">
               {getInitials(team.name)}
             </AvatarFallback>
           </Avatar>
-          <div className="min-w-0 flex-1 space-y-1.5">
-            <p className="truncate text-sm font-semibold leading-none">{team.name}</p>
-            <Badge variant="outline" className="text-xs">
-              {team.type === "solo" ? "Solo" : "Duplas"}
-            </Badge>
+          <div className="min-w-0 flex-1 space-y-3">
+            <div className="space-y-1.5">
+              <div className="flex items-center gap-2">
+                <p className="truncate text-sm font-semibold leading-none">{team.name}</p>
+                <Badge variant="outline" className="shrink-0 text-xs">
+                  {team.type === "solo" ? "Solo" : "Duplas"}
+                </Badge>
+              </div>
+              <p className="truncate text-xs text-muted-foreground">{partnerLabel}</p>
+            </div>
+
+            <div className="grid gap-3 sm:grid-cols-[auto_auto_1fr] sm:items-center">
+              <div>
+                <p className="caption text-muted-foreground">Desempenho</p>
+                <p className="text-sm font-medium">
+                  {team.summary.wins}V · {team.summary.losses}D
+                </p>
+              </div>
+              <div>
+                <p className="caption text-muted-foreground">Taxa</p>
+                <p className="text-sm font-medium">{team.summary.winRate.toFixed(1)}%</p>
+              </div>
+              <div className="sm:justify-self-end">
+                <p className="caption mb-1 text-muted-foreground">Últimas 5</p>
+                <RecentResultsDots results={team.summary.lastFiveResults} teamName={team.name} />
+              </div>
+            </div>
           </div>
-          <ChevronRight className="size-4 shrink-0 text-muted-foreground" />
+          <ChevronRight className="mt-1 size-4 shrink-0 text-muted-foreground" />
         </div>
-        <div className="border-t border-border px-4 py-2.5 text-xs text-muted-foreground">
-          {team.members.length} membro(s)
+        <div className="grid gap-2 border-t border-border px-4 py-2.5 text-xs text-muted-foreground sm:grid-cols-2">
+          <p>
+            {team.summary.totalMatches === 0
+              ? "Nenhuma partida registrada"
+              : `${team.summary.totalMatches} ${team.summary.totalMatches === 1 ? "partida registrada" : "partidas registradas"}`}
+          </p>
+          <p className="sm:text-right">
+            {team.summary.lastPlayedAt ? `Última partida em ${formatLastPlayedAt(team.summary.lastPlayedAt)}` : "Aguardando primeira partida"}
+          </p>
         </div>
       </Card>
     </Link>

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
-const cardVariants = cva("rounded-xl border", {
+const cardVariants = cva("rounded-lg border", {
   variants: {
     variant: {
       default: "border-border bg-surface shadow-lg",

--- a/src/lib/teams.test.ts
+++ b/src/lib/teams.test.ts
@@ -2,19 +2,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock Prisma — never import real Prisma in tests
 const mockTeamMemberFindUnique = vi.fn();
+const mockTeamMemberFindMany = vi.fn();
 const mockTeamMemberCreate = vi.fn();
 const mockTeamMemberDelete = vi.fn();
 const mockTeamFindUnique = vi.fn();
+const mockMatchFindMany = vi.fn();
 
 vi.mock("@/lib/prisma", () => ({
   prisma: {
     teamMember: {
       findUnique: (...args: unknown[]) => mockTeamMemberFindUnique(...args),
+      findMany: (...args: unknown[]) => mockTeamMemberFindMany(...args),
       create: (...args: unknown[]) => mockTeamMemberCreate(...args),
       delete: (...args: unknown[]) => mockTeamMemberDelete(...args),
     },
     team: {
       findUnique: (...args: unknown[]) => mockTeamFindUnique(...args),
+    },
+    match: {
+      findMany: (...args: unknown[]) => mockMatchFindMany(...args),
     },
   },
 }));
@@ -46,9 +52,133 @@ describe("teams.ts — member management", () => {
   beforeEach(() => {
     vi.resetModules();
     mockTeamMemberFindUnique.mockReset();
+    mockTeamMemberFindMany.mockReset();
     mockTeamMemberCreate.mockReset();
     mockTeamMemberDelete.mockReset();
     mockTeamFindUnique.mockReset();
+    mockMatchFindMany.mockReset();
+  });
+
+  describe("listUserTeamsWithPartners", () => {
+    it("returns active user teams with partner display data", async () => {
+      const { listUserTeamsWithPartners } = await import("@/lib/teams");
+
+      mockTeamMemberFindMany.mockResolvedValueOnce([
+        {
+          joinedAt: new Date("2026-01-10T00:00:00.000Z"),
+          team: {
+            ...makeTeam({
+              id: "team-duo",
+              name: "dupla afiada",
+              members: [
+                { userId: "user-creator", joinedAt: new Date("2026-01-01T00:00:00.000Z") },
+                { userId: "user-partner", joinedAt: new Date("2026-01-02T00:00:00.000Z") },
+              ],
+            }),
+            members: [
+              {
+                userId: "user-creator",
+                joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+                user: { id: "user-creator", username: "gui.dev", displayName: "Gui" },
+              },
+              {
+                userId: "user-partner",
+                joinedAt: new Date("2026-01-02T00:00:00.000Z"),
+                user: { id: "user-partner", username: "jean.dev", displayName: "Jean" },
+              },
+            ],
+          },
+        },
+        {
+          joinedAt: new Date("2026-01-09T00:00:00.000Z"),
+          team: {
+            ...makeTeam({
+              id: "team-solo",
+              type: "solo",
+              name: "lobo solo",
+              members: [
+                { userId: "user-creator", joinedAt: new Date("2026-01-01T00:00:00.000Z") },
+              ],
+            }),
+            members: [
+              {
+                userId: "user-creator",
+                joinedAt: new Date("2026-01-01T00:00:00.000Z"),
+                user: { id: "user-creator", username: "gui.dev", displayName: "Gui" },
+              },
+            ],
+          },
+        },
+      ]);
+      mockMatchFindMany.mockResolvedValueOnce([
+        {
+          id: "match-1",
+          teamAId: "team-duo",
+          teamBId: "team-rival",
+          winnerTeamId: "team-duo",
+          playedAt: new Date("2026-01-11T00:00:00.000Z"),
+          note: null,
+        },
+      ]);
+
+      const result = await listUserTeamsWithPartners("user-creator");
+
+      expect(mockTeamMemberFindMany).toHaveBeenCalledWith({
+        where: {
+          userId: "user-creator",
+          team: { status: "active" },
+        },
+        include: {
+          team: {
+            include: {
+              members: {
+                include: {
+                  user: {
+                    select: {
+                      id: true,
+                      username: true,
+                      displayName: true,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        orderBy: { joinedAt: "desc" },
+      });
+      expect(mockMatchFindMany).toHaveBeenCalledWith({
+        where: {
+          OR: [{ teamAId: { in: ["team-duo", "team-solo"] } }, { teamBId: { in: ["team-duo", "team-solo"] } }],
+        },
+        orderBy: { playedAt: "desc" },
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]?.partners).toEqual([
+        {
+          userId: "user-partner",
+          username: "jean.dev",
+          displayName: "Jean",
+        },
+      ]);
+      expect(result[0]?.summary).toEqual({
+        wins: 1,
+        losses: 0,
+        winRate: 100,
+        totalMatches: 1,
+        lastFiveResults: ["win"],
+        lastPlayedAt: "2026-01-11T00:00:00.000Z",
+      });
+      expect(result[1]?.summary).toEqual({
+        wins: 0,
+        losses: 0,
+        winRate: 0,
+        totalMatches: 0,
+        lastFiveResults: [],
+        lastPlayedAt: null,
+      });
+      expect(result[1]?.partners).toEqual([]);
+    });
   });
 
   describe("addTeamMember", () => {

--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -1,5 +1,44 @@
 import { prisma } from "@/lib/prisma";
-import type { TeamRecord } from "@/lib/types";
+import { computeTeamStats } from "@/lib/stats";
+import type { MatchRecord, TeamRecord } from "@/lib/types";
+
+export type TeamPartnerRecord = {
+  userId: string;
+  username: string;
+  displayName: string;
+};
+
+export type UserTeamOverview = TeamRecord & {
+  partners: TeamPartnerRecord[];
+  summary: {
+    wins: number;
+    losses: number;
+    winRate: number;
+    totalMatches: number;
+    lastFiveResults: Array<"win" | "loss">;
+    lastPlayedAt: string | null;
+  };
+};
+
+function normalizeMatch(match: {
+  id: string;
+  teamAId: string;
+  teamBId: string;
+  winnerTeamId: string;
+  playedAt: Date;
+  note: string | null;
+}): MatchRecord {
+  return {
+    id: match.id,
+    teamAId: match.teamAId,
+    teamBId: match.teamBId,
+    winnerTeamId: match.winnerTeamId,
+    loserTeamId:
+      match.teamAId === match.winnerTeamId ? match.teamBId : match.teamAId,
+    playedAt: match.playedAt.toISOString(),
+    note: match.note,
+  };
+}
 
 function normalizeTeam(team: {
   id: string;
@@ -76,6 +115,77 @@ export async function listUserTeams(
   });
 
   return memberships.map((m) => normalizeTeam(m.team));
+}
+
+export async function listUserTeamsWithPartners(
+  userId: string,
+  includeArchived = false,
+): Promise<UserTeamOverview[]> {
+  const memberships = await prisma.teamMember.findMany({
+    where: {
+      userId,
+      ...(includeArchived ? {} : { team: { status: "active" } }),
+    },
+    include: {
+      team: {
+        include: {
+          members: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  username: true,
+                  displayName: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    orderBy: { joinedAt: "desc" },
+  });
+
+  const teams = memberships.map(({ team }) => team);
+  if (teams.length === 0) return [];
+
+  const teamIds = teams.map((team) => team.id);
+  const matchRows = await prisma.match.findMany({
+    where: {
+      OR: [{ teamAId: { in: teamIds } }, { teamBId: { in: teamIds } }],
+    },
+    orderBy: { playedAt: "desc" },
+  });
+  const matches = matchRows.map(normalizeMatch);
+
+  return teams.map((team) => {
+    const summary = computeTeamStats(team.id, matches);
+    const lastPlayedAt =
+      matches.find((match) => match.teamAId === team.id || match.teamBId === team.id)?.playedAt ?? null;
+
+    return {
+      ...normalizeTeam(team),
+      partners: team.members
+        .filter((member) => member.userId !== userId)
+        .map((member) => {
+          const username = member.user?.username ?? member.userId;
+
+          return {
+            userId: member.userId,
+            username,
+            displayName: member.user?.displayName ?? username,
+          };
+        }),
+      summary: {
+        wins: summary.wins,
+        losses: summary.losses,
+        winRate: summary.winRate,
+        totalMatches: summary.totalMatches,
+        lastFiveResults: summary.lastFiveResults,
+        lastPlayedAt,
+      },
+    };
+  });
 }
 
 export async function getTeamById(teamId: string): Promise<TeamRecord | null> {


### PR DESCRIPTION
## Summary
- align the teams page header and content split with the updated ranking layout
- add partner-based filtering plus richer team card summaries derived from match history
- reduce the base card radius from 28px to 22px for more consistent surface styling

## Testing
- npm run typecheck
- npm run test -- src/lib/teams.test.ts src/components/teams/team-card.test.tsx
- npm run test -- src/components/ui/composition.test.tsx src/components/teams/team-card.test.tsx